### PR TITLE
feat: adding context to unique node id

### DIFF
--- a/test/util/quads.spec.ts
+++ b/test/util/quads.spec.ts
@@ -4,36 +4,40 @@ import { serialize2quads } from '../../src/util/quads'
 import { assert } from 'chai'
 
 describe('Quad Generation', withShell(shell => {
+  const context = 'test'
+  const domain = 'https://uni-ulm.de/r-ast/'
+
   const compareQuads = async(code: string, expected: string) => {
     const ast = await retrieveAst(shell, code)
     const decorated = decorateAst(ast).decoratedAst
-    const serialized = serialize2quads(decorated, { context: 'test' })
+    const serialized = serialize2quads(decorated, { context, domain })
     assert.strictEqual(serialized.trim(), expected.trim())
   }
 
   it('should generate quads', async() => {
+    const idPrefix =  `${domain}${context}/`
     // ids are deterministic, so we can compare the quads
     await compareQuads('1', `
-<https://uni-ulm.de/r-ast/0> <https://uni-ulm.de/r-ast/type> "exprlist"@string <test> .
-<https://uni-ulm.de/r-ast/0> <https://uni-ulm.de/r-ast/children-0> <https://uni-ulm.de/r-ast/1> <test> .
-<https://uni-ulm.de/r-ast/1> <https://uni-ulm.de/r-ast/location> <https://uni-ulm.de/r-ast/2> <test> .
-<https://uni-ulm.de/r-ast/2> <https://uni-ulm.de/r-ast/start> <https://uni-ulm.de/r-ast/3> <test> .
-<https://uni-ulm.de/r-ast/3> <https://uni-ulm.de/r-ast/line> "1"@number <test> .
-<https://uni-ulm.de/r-ast/3> <https://uni-ulm.de/r-ast/column> "1"@number <test> .
-<https://uni-ulm.de/r-ast/2> <https://uni-ulm.de/r-ast/end> <https://uni-ulm.de/r-ast/4> <test> .
-<https://uni-ulm.de/r-ast/4> <https://uni-ulm.de/r-ast/line> "1"@number <test> .
-<https://uni-ulm.de/r-ast/4> <https://uni-ulm.de/r-ast/column> "1"@number <test> .
-<https://uni-ulm.de/r-ast/1> <https://uni-ulm.de/r-ast/lexeme> "1"@string <test> .
-<https://uni-ulm.de/r-ast/1> <https://uni-ulm.de/r-ast/type> "NUM_CONST"@string <test> .
-<https://uni-ulm.de/r-ast/1> <https://uni-ulm.de/r-ast/content> <https://uni-ulm.de/r-ast/5> <test> .
-<https://uni-ulm.de/r-ast/5> <https://uni-ulm.de/r-ast/num> "1"@number <test> .
-<https://uni-ulm.de/r-ast/5> <https://uni-ulm.de/r-ast/complexNumber> "false"@boolean <test> .
-<https://uni-ulm.de/r-ast/5> <https://uni-ulm.de/r-ast/markedAsInt> "false"@boolean <test> .
-<https://uni-ulm.de/r-ast/1> <https://uni-ulm.de/r-ast/info> <https://uni-ulm.de/r-ast/6> <test> .
-<https://uni-ulm.de/r-ast/6> <https://uni-ulm.de/r-ast/id> "0"@string <test> .
-<https://uni-ulm.de/r-ast/6> <https://uni-ulm.de/r-ast/parent> "1"@string <test> .
-<https://uni-ulm.de/r-ast/0> <https://uni-ulm.de/r-ast/info> <https://uni-ulm.de/r-ast/7> <test> .
-<https://uni-ulm.de/r-ast/7> <https://uni-ulm.de/r-ast/id> "1"@string <test> .
+<${idPrefix}0> <${domain}type> "exprlist"@string <${context}> .
+<${idPrefix}0> <${domain}children-0> <${idPrefix}1> <${context}> .
+<${idPrefix}1> <${domain}location> <${idPrefix}2> <${context}> .
+<${idPrefix}2> <${domain}start> <${idPrefix}3> <${context}> .
+<${idPrefix}3> <${domain}line> "1"@number <${context}> .
+<${idPrefix}3> <${domain}column> "1"@number <${context}> .
+<${idPrefix}2> <${domain}end> <${idPrefix}4> <${context}> .
+<${idPrefix}4> <${domain}line> "1"@number <${context}> .
+<${idPrefix}4> <${domain}column> "1"@number <${context}> .
+<${idPrefix}1> <${domain}lexeme> "1"@string <${context}> .
+<${idPrefix}1> <${domain}type> "NUM_CONST"@string <${context}> .
+<${idPrefix}1> <${domain}content> <${idPrefix}5> <${context}> .
+<${idPrefix}5> <${domain}num> "1"@number <${context}> .
+<${idPrefix}5> <${domain}complexNumber> "false"@boolean <${context}> .
+<${idPrefix}5> <${domain}markedAsInt> "false"@boolean <${context}> .
+<${idPrefix}1> <${domain}info> <${idPrefix}6> <${context}> .
+<${idPrefix}6> <${domain}id> "0"@string <${context}> .
+<${idPrefix}6> <${domain}parent> "1"@string <${context}> .
+<${idPrefix}0> <${domain}info> <${idPrefix}7> <${context}> .
+<${idPrefix}7> <${domain}id> "1"@string <${context}> .
     `)
   })
 }))


### PR DESCRIPTION
Now, each id is automatically prefixed by the active context allowing for the merge of huge datasets without duplicate ids.