### PR TITLE
Ability to mark a slicing test as expected to fail

### DIFF
--- a/test/functionality/_helper/shell.ts
+++ b/test/functionality/_helper/shell.ts
@@ -405,6 +405,8 @@ function testWrapper(skip: boolean | undefined, shouldFail: boolean, testName: s
 	}
 }
 
+export type TestCaseFailType = 'shell' | 'tree-sitter' | 'both' | undefined;
+
 export function assertSliced(
 	name: TestLabel,
 	shell: RShell,
@@ -412,7 +414,7 @@ export function assertSliced(
 	criteria: SlicingCriteria,
 	expected: string,
 	userConfig?: Partial<TestConfigurationWithOutput> & { autoSelectIf?: AutoSelectPredicate, skipTreeSitter?: boolean, skipCompare?: boolean },
-	testCaseFailType?: 'shell' | 'tree-sitter' | 'both' | undefined,
+	testCaseFailType?: TestCaseFailType,
 	getId: () => IdGenerator<NoInfo> = () => deterministicCountingIdGenerator(0),
 ) {
 	const fullname = `${JSON.stringify(criteria)} ${decorateLabelContext(name, ['slice'])}`;


### PR DESCRIPTION
Closes #1260

See issue for description.

The developer can now choose between which test cases should fail:
- 'both': both shell and tree-sitter test cases
- 'shell': only the shell test case
- 'tree-sitter': only the tree-sitter test case
