### PR TITLE
Fix HTML nesting error

### DIFF
--- a/src/documentation/print-readme.ts
+++ b/src/documentation/print-readme.ts
@@ -74,7 +74,7 @@ The following showcases the dependency view of the [Visual Studio Code extension
   `), '    ')}
 
 * 🚀 **fast data- and control-flow graphs**\\
-  Within just ${'<i>' + textWithTooltip(roundToDecimals(await getLatestDfAnalysisTime('"social-science" Benchmark Suite (tree-sitter)'), 1) + ' ms</i>', 'This measurement is automatically fetched from the latest benchmark!')} (as of ${new Date(await getLastBenchmarkUpdate()).toLocaleDateString('en-US', dateOptions)}), 
+  Within just ${'<i>' + textWithTooltip(roundToDecimals(await getLatestDfAnalysisTime('"social-science" Benchmark Suite (tree-sitter)'), 1) + ' ms', 'This measurement is automatically fetched from the latest benchmark!') + '</i>'} (as of ${new Date(await getLastBenchmarkUpdate()).toLocaleDateString('en-US', dateOptions)}), 
   _flowR_ can analyze the data- and control-flow of the average real-world R script. See the [benchmarks](https://flowr-analysis.github.io/flowr/wiki/stats/benchmark) for more information,
   and consult the [wiki pages](${FlowrWikiBaseRef}/Dataflow-Graph) for more details on the dataflow graph.
 


### PR DESCRIPTION
I noticed a small formatting error when looking at the new auto-updating benchmark statistic in the README:

![image](https://github.com/user-attachments/assets/7e710444-cfbc-468b-b63f-19a532d0a9c8)

```
Within just <i><span title="This measurement is automatically fetched from the latest benchmark!">118 ms</i></span>
```

This commit should fix the HTML tag nesting. Did not run the code though ✌🏽 