### PR TITLE
Bug-Fix: Processing of nested Arguments

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -164,7 +164,7 @@ export const defaultConfigOptions: FlowrConfigOptions = {
 	defaultEngine: 'r-shell',
 	solver:        {
 		variables:       VariableResolve.Alias,
-		pointerTracking: false,
+		pointerTracking: true,
 		resolveSource:   {
 			dropPaths:             DropPathsOption.No,
 			ignoreCapitalization:  true,

--- a/src/dataflow/environments/built-in-config.ts
+++ b/src/dataflow/environments/built-in-config.ts
@@ -32,7 +32,7 @@ export interface BuiltInConstantDefinition<Value> extends BaseBuiltInDefinition 
 export interface BuiltInFunctionDefinition<BuiltInProcessor extends BuiltInMappingName> extends BaseBuiltInDefinition {
     readonly type:      'function';
     readonly processor: BuiltInProcessor;
-    readonly config:    ConfigOfBuiltInMappingName<BuiltInProcessor>
+    readonly config?:   ConfigOfBuiltInMappingName<BuiltInProcessor>
 }
 
 /**
@@ -82,6 +82,7 @@ export function registerBuiltInFunctions<BuiltInProcessor extends BuiltInMapping
 			controlDependencies: undefined,
 			/* eslint-disable-next-line @typescript-eslint/no-explicit-any,@typescript-eslint/no-unsafe-argument */
 			processor:           (name, args, rootId, data) => mappedProcessor(name, args, rootId, data, config as any),
+			config,
 			name,
 			nodeId:              BuiltIn
 		}];
@@ -102,9 +103,14 @@ export function registerReplacementFunctions(
 		for(const suffix of suffixes) {
 			const effectiveName = `${assignment}${suffix}`;
 			const d: IdentifierDefinition[] = [{
-				type:                ReferenceType.BuiltInFunction,
-				definedAt:           BuiltIn,
-				processor:           (name, args, rootId, data) => replacer(name, args, rootId, data, { makeMaybe: true, assignmentOperator: suffix, readIndices: config.readIndices }),
+				type:      ReferenceType.BuiltInFunction,
+				definedAt: BuiltIn,
+				processor: (name, args, rootId, data) => replacer(name, args, rootId, data, { makeMaybe: true, assignmentOperator: suffix, readIndices: config.readIndices }),
+				config:    {
+					...config,
+					assignmentOperator: suffix,
+					makeMaybe:          true
+				},
 				name:                effectiveName,
 				controlDependencies: undefined,
 				nodeId:              BuiltIn

--- a/src/dataflow/environments/built-in-config.ts
+++ b/src/dataflow/environments/built-in-config.ts
@@ -42,6 +42,7 @@ export interface BuiltInFunctionDefinition<BuiltInProcessor extends BuiltInMappi
 export interface BuiltInReplacementDefinition extends BaseBuiltInDefinition {
     readonly type:     'replacement';
     readonly suffixes: readonly ('<<-' | '<-')[];
+	readonly config:      { readIndices: boolean }
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
@@ -93,7 +94,7 @@ export function registerBuiltInFunctions<BuiltInProcessor extends BuiltInMapping
 
 /* registers all combinations of replacements */
 export function registerReplacementFunctions(
-	{ names, suffixes, assumePrimitive }: BuiltInReplacementDefinition
+	{ names, suffixes, assumePrimitive, config }: BuiltInReplacementDefinition
 ): void {
 	const replacer = BuiltInProcessorMapper['builtin:replacement'];
 	guard(replacer !== undefined, () => 'Processor for builtin:replacement is undefined!');
@@ -103,7 +104,7 @@ export function registerReplacementFunctions(
 			const d: IdentifierDefinition[] = [{
 				type:                ReferenceType.BuiltInFunction,
 				definedAt:           BuiltIn,
-				processor:           (name, args, rootId, data) => replacer(name, args, rootId, data, { makeMaybe: true, assignmentOperator: suffix }),
+				processor:           (name, args, rootId, data) => replacer(name, args, rootId, data, { makeMaybe: true, assignmentOperator: suffix, readIndices: config.readIndices }),
 				name:                effectiveName,
 				controlDependencies: undefined,
 				nodeId:              BuiltIn

--- a/src/dataflow/environments/built-in.ts
+++ b/src/dataflow/environments/built-in.ts
@@ -53,6 +53,7 @@ export interface BuiltInIdentifierDefinition extends IdentifierReference {
 	type:      ReferenceType.BuiltInFunction
 	definedAt: typeof BuiltIn
 	processor: BuiltInIdentifierProcessor
+	config?:   object
 }
 
 export interface BuiltInIdentifierConstant<T = unknown> extends IdentifierReference {
@@ -105,7 +106,7 @@ function defaultBuiltInProcessor<OtherInfo>(
 	return res;
 }
 
-export function registerBuiltInFunctions<Config, Proc extends BuiltInIdentifierProcessorWithConfig<Config>>(
+export function registerBuiltInFunctions<Config extends object, Proc extends BuiltInIdentifierProcessorWithConfig<Config>>(
 	both:      boolean,
 	names:     readonly Identifier[],
 	processor: Proc,
@@ -118,6 +119,7 @@ export function registerBuiltInFunctions<Config, Proc extends BuiltInIdentifierP
 			definedAt:           BuiltIn,
 			controlDependencies: undefined,
 			processor:           (name, args, rootId, data) => processor(name, args, rootId, data, config),
+			config,
 			name,
 			nodeId:              BuiltIn
 		}];

--- a/src/dataflow/environments/default-builtin-config.ts
+++ b/src/dataflow/environments/default-builtin-config.ts
@@ -151,6 +151,17 @@ export const DefaultBuiltinConfig: BuiltInDefinitions = [
 	{
 		type:     'replacement',
 		suffixes: ['<-', '<<-'],
-		names:    ['[', '[[', '$', '@', 'names', 'dimnames', 'attributes', 'attr', 'class', 'levels', 'rownames', 'colnames', 'body', 'environment', 'formals']
+		names:    ['[', '[[', 'names', 'dimnames', 'attributes', 'attr', 'class', 'levels', 'rownames', 'colnames', 'body', 'environment', 'formals'],
+		config:   {
+			readIndices: true
+		}
+	},
+	{
+		type:     'replacement',
+		suffixes: ['<-', '<<-'],
+		names:    ['$', '@'],
+		config:   {
+			readIndices: false
+		}
 	}
 ];

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-access.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-access.ts
@@ -161,25 +161,10 @@ function processNumberBasedAccess<OtherInfo>(
 	return fnCall;
 }
 
-/**
- * Processes different types of string-based access operations.
- *
- * Example:
- * ```r
- * a$foo
- * a@foo
- * ```
- */
-function processStringBasedAccess<OtherInfo>(
-	args: readonly RFunctionArgument<OtherInfo & ParentInformation>[],
-	data: DataflowProcessorInformation<OtherInfo & ParentInformation>,
-	name: RSymbol<OtherInfo & ParentInformation, string>,
-	rootId: NodeId,
-	config: ForceArguments,
-) {
+export function symbolArgumentsToStrings<OtherInfo>(args: readonly RFunctionArgument<OtherInfo & ParentInformation>[], firstIndexInclusive = 1, lastIndexInclusive = args.length - 1) {
 	const newArgs = [...args];
 	// if the argument is a symbol, we convert it to a string for this perspective
-	for(let i = 1; i < newArgs.length; i++) {
+	for(let i = firstIndexInclusive; i <= lastIndexInclusive; i++) {
 		const arg = newArgs[i];
 		if(arg !== EmptyArgument && arg.value?.type === RType.Symbol) {
 			newArgs[i] = {
@@ -197,6 +182,26 @@ function processStringBasedAccess<OtherInfo>(
 			};
 		}
 	}
+	return newArgs;
+}
+
+/**
+ * Processes different types of string-based access operations.
+ *
+ * Example:
+ * ```r
+ * a$foo
+ * a@foo
+ * ```
+ */
+function processStringBasedAccess<OtherInfo>(
+	args: readonly RFunctionArgument<OtherInfo & ParentInformation>[],
+	data: DataflowProcessorInformation<OtherInfo & ParentInformation>,
+	name: RSymbol<OtherInfo & ParentInformation, string>,
+	rootId: NodeId,
+	config: ForceArguments,
+) {
+	const newArgs = symbolArgumentsToStrings(args);
 
 	const fnCall = processKnownFunctionCall({ name, args: newArgs, rootId, data, forceArgs: config.forceArgs });
 

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-access.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-access.ts
@@ -136,6 +136,7 @@ function processNumberBasedAccess<OtherInfo>(
 		definedAt:           BuiltIn,
 		controlDependencies: undefined,
 		processor:           (name, args, rootId, data) => tableAssignmentProcessor(name, args, rootId, data, outInfo),
+		config:              {},
 		name:                ':=',
 		nodeId:              BuiltIn,
 	}]);

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-assignment.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-assignment.ts
@@ -268,7 +268,7 @@ export function markAsAssignment(
 	if(getConfig().solver.pointerTracking) {
 		let indicesCollection: ContainerIndicesCollection = undefined;
 		if(sourceIds.length === 1) {
-			// support for tracking indices
+			// support for tracking indices.
 			// Indices were defined for the vertex e.g. a <- list(c = 1) or a$b <- list(c = 1)
 			indicesCollection = information.graph.getVertex(sourceIds[0])?.indicesCollection;
 

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-assignment.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-assignment.ts
@@ -5,7 +5,7 @@ import { guard } from '../../../../../../util/assert';
 import { log, LogLevel } from '../../../../../../util/log';
 import { unpackArgument } from '../argument/unpack-argument';
 import { processAsNamedCall } from '../../../process-named-call';
-import { toUnnamedArgument } from '../argument/make-argument';
+import { toUnnamedArgument, wrapArgumentsUnnamed } from '../argument/make-argument';
 import type {
 	ParentInformation,
 	RNodeWithParent
@@ -13,29 +13,35 @@ import type {
 import type { Base, Location, RNode } from '../../../../../../r-bridge/lang-4.x/ast/model/model';
 import type { RSymbol } from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-symbol';
 import { RType } from '../../../../../../r-bridge/lang-4.x/ast/model/type';
-import type { RFunctionArgument } from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-function-call';
+import type {
+	EmptyArgument,
+	RFunctionArgument
+} from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-function-call';
 import { type NodeId } from '../../../../../../r-bridge/lang-4.x/ast/model/processing/node-id';
 import { dataflowLogger } from '../../../../../logger';
 import type {
 	IdentifierReference,
 	InGraphIdentifierDefinition,
 	InGraphReferenceType } from '../../../../../environments/identifier';
-import { ReferenceType
+import {
+	ReferenceType
 } from '../../../../../environments/identifier';
 import { overwriteEnvironment } from '../../../../../environments/overwrite';
 import type { RString } from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-string';
 import { removeRQuotes } from '../../../../../../r-bridge/retriever';
 import type { RUnnamedArgument } from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-argument';
-import { VertexType } from '../../../../../graph/vertex';
 import type { ContainerIndicesCollection } from '../../../../../graph/vertex';
+import { VertexType } from '../../../../../graph/vertex';
 import { define } from '../../../../../environments/define';
 import { EdgeType } from '../../../../../graph/edge';
 import type { ForceArguments } from '../common';
 import type { REnvironmentInformation } from '../../../../../environments/environment';
 import type { DataflowGraph } from '../../../../../graph/graph';
-import { getAliases } from '../../../../../environments/resolve-by-name';
+import { getAliases, resolveByName } from '../../../../../environments/resolve-by-name';
 import { addSubIndicesToLeafIndices, resolveIndicesByName } from '../../../../../../util/containers';
 import { getConfig } from '../../../../../../config';
+import { processReplacementFunction } from './built-in-replacement';
+import { markAsOnlyBuiltIn } from '../named-call-handling';
 
 function toReplacementSymbol<OtherInfo>(target: RNodeWithParent<OtherInfo & ParentInformation> & Base<OtherInfo> & Location, prefix: string, superAssignment: boolean): RSymbol<OtherInfo & ParentInformation> {
 	return {
@@ -80,6 +86,42 @@ function findRootAccess<OtherInfo>(node: RNode<OtherInfo & ParentInformation>): 
 	}
 }
 
+function tryReplacementPassingIndices<OtherInfo>(
+	functionName: RSymbol<OtherInfo & ParentInformation>,
+	data: DataflowProcessorInformation<OtherInfo & ParentInformation>,
+	name: string,
+	args: readonly (RNode<OtherInfo & ParentInformation> | typeof EmptyArgument | undefined)[],
+	indices: ContainerIndicesCollection
+): DataflowInformation {
+	const resolved = resolveByName(functionName.content, data.environment, ReferenceType.Function) ?? [];
+
+	// yield for unsupported pass along!
+	if(resolved.length !== 1 || resolved[0].type !== ReferenceType.BuiltInFunction) {
+		return processAsNamedCall(functionName, data, name, args);
+	}
+
+
+	const info = processReplacementFunction(
+		{
+			type:      RType.Symbol,
+			info:      functionName.info,
+			content:   name,
+			lexeme:    functionName.lexeme,
+			location:  functionName.location,
+			namespace: undefined
+		},
+		wrapArgumentsUnnamed(args, data.completeAst.idMap),
+		functionName.info.id,
+		data,
+		{
+			...(resolved[0].config ?? {}),
+			activeIndices: indices
+		}
+	);
+	markAsOnlyBuiltIn(info.graph, functionName.info.id);
+	return info;
+}
+
 /**
  * Processes an assignment, i.e., `<target> <- <source>`.
  * Handling it as a function call \`&lt;-\` `(<target>, <source>)`.
@@ -118,11 +160,11 @@ export function processAssignment<OtherInfo>(
 		/* as replacement functions take precedence over the lhs fn-call (i.e., `names(x) <- ...` is independent from the definition of `names`), we do not have to process the call */
 		dataflowLogger.debug(`Assignment ${name.content} has a function call as target ==> replacement function ${target.lexeme}`);
 		const replacement = toReplacementSymbol(target, target.functionName.content, config.superAssignment ?? false);
-		return processAsNamedCall(replacement, data, replacement.content, [...target.arguments, source]);
+		return tryReplacementPassingIndices(replacement, data, replacement.content, [...target.arguments, source], config.indicesCollection);
 	} else if(config.canBeReplacement && type === RType.Access) {
 		dataflowLogger.debug(`Assignment ${name.content} has an access-type node as target ==> replacement function ${target.lexeme}`);
 		const replacement = toReplacementSymbol(target, target.operator, config.superAssignment ?? false);
-		return processAsNamedCall(replacement, data, replacement.content, [toUnnamedArgument(target.accessed, data.completeAst.idMap), ...target.access, source]);
+		return tryReplacementPassingIndices(replacement, data, replacement.content, [toUnnamedArgument(target.accessed, data.completeAst.idMap), ...target.access, source], config.indicesCollection);
 	} else if(type === RType.Access) {
 		const rootArg = findRootAccess(target);
 		if(rootArg) {

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-assignment.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-assignment.ts
@@ -116,11 +116,11 @@ export function processAssignment<OtherInfo>(
 		});
 	} else if(config.canBeReplacement && type === RType.FunctionCall && named) {
 		/* as replacement functions take precedence over the lhs fn-call (i.e., `names(x) <- ...` is independent from the definition of `names`), we do not have to process the call */
-		dataflowLogger.debug(`Assignment ${name.content} has a function call as target => replacement function ${target.lexeme}`);
+		dataflowLogger.debug(`Assignment ${name.content} has a function call as target ==> replacement function ${target.lexeme}`);
 		const replacement = toReplacementSymbol(target, target.functionName.content, config.superAssignment ?? false);
 		return processAsNamedCall(replacement, data, replacement.content, [...target.arguments, source]);
 	} else if(config.canBeReplacement && type === RType.Access) {
-		dataflowLogger.debug(`Assignment ${name.content} has an access as target => replacement function ${target.lexeme}`);
+		dataflowLogger.debug(`Assignment ${name.content} has an access-type node as target ==> replacement function ${target.lexeme}`);
 		const replacement = toReplacementSymbol(target, target.operator, config.superAssignment ?? false);
 		return processAsNamedCall(replacement, data, replacement.content, [toUnnamedArgument(target.accessed, data.completeAst.idMap), ...target.access, source]);
 	} else if(type === RType.Access) {

--- a/src/dataflow/internal/process/functions/call/common.ts
+++ b/src/dataflow/internal/process/functions/call/common.ts
@@ -147,7 +147,7 @@ export interface PatchFunctionCallInput<OtherInfo> {
 	readonly rootId:                NodeId
 	readonly name:                  RSymbol<OtherInfo & ParentInformation>
 	readonly data:                  DataflowProcessorInformation<OtherInfo & ParentInformation>
-	readonly argumentProcessResult: readonly (DataflowInformation | undefined)[]
+	readonly argumentProcessResult: readonly (Pick<DataflowInformation, 'entryPoint'> | undefined)[]
 }
 
 export function patchFunctionCall<OtherInfo>(

--- a/src/dataflow/internal/process/process-named-call.ts
+++ b/src/dataflow/internal/process/process-named-call.ts
@@ -7,6 +7,9 @@ import type { Base, RNode, Location } from '../../../r-bridge/lang-4.x/ast/model
 import type { ParentInformation } from '../../../r-bridge/lang-4.x/ast/model/processing/decorate';
 import type { EmptyArgument } from '../../../r-bridge/lang-4.x/ast/model/nodes/r-function-call';
 
+/**
+ * Helper function for {@link processNamedCall} using the given `functionName` as the name of the function.
+ */
 export function processAsNamedCall<OtherInfo>(
 	functionName: RNode<OtherInfo & ParentInformation> & Base<OtherInfo> & Location,
 	data: DataflowProcessorInformation<OtherInfo & ParentInformation>,

--- a/src/dataflow/processor.ts
+++ b/src/dataflow/processor.ts
@@ -40,6 +40,7 @@ export interface DataflowProcessorInformation<OtherInfo> {
 	 * The chain of control-flow {@link NodeId}s that lead to the current node (e.g., of known ifs).
 	 */
 	readonly controlDependencies: ControlDependency[] | undefined
+	
 }
 
 export type DataflowProcessor<OtherInfo, NodeType extends RNodeWithParent<OtherInfo>> = (node: NodeType, data: DataflowProcessorInformation<OtherInfo>) => DataflowInformation

--- a/test/functionality/dataflow/processing-of-elements/atomic/dataflow-atomic.test.ts
+++ b/test/functionality/dataflow/processing-of-elements/atomic/dataflow-atomic.test.ts
@@ -137,10 +137,13 @@ describe.sequential('Atomic (dataflow information)', withShell(shell => {
 		);
 		assertDataflow(label('nested assign', ['name-normal', 'dollar-access', ...OperatorDatabase['<-'].capabilities, 'replacement-functions']), shell,
 			'a$b$c <- 5',  emptyGraph()
-				.use(1, 'x')
-				.call(3, '$<-', [argumentInCall(0), argumentInCall(1), argumentInCall(4)], { returns: [0], reads: [1, BuiltIn], onlyBuiltIn: true })
+				.call(3, '$<-', [argumentInCall(0), argumentInCall(1), argumentInCall(7)], { returns: [0], reads: [1, 6], onlyBuiltIn: true })
+				.definedBy(3, 6)
+				.call(6, '$<-', [argumentInCall(3), argumentInCall(4), argumentInCall(7)], { returns: [], reads: [4], onlyBuiltIn: true })
 				.constant(4)
-				.defineVariable(0, 'a', { definedBy: [4, 3] })
+				.defineVariable(0, 'a', { definedBy: [7, 3] })
+				.constant(1)
+				.constant(7)
 		);
 	});
 
@@ -360,6 +363,7 @@ describe.sequential('Atomic (dataflow information)', withShell(shell => {
 					.constant(0)
 					.defineVariable(1, 'x', { definedBy: [0, 2] })
 					.defineVariable(3, 'a', { definedBy: [2, 6] })
+					.reads(3, 6)
 			);
 		});
 		describe('Double Assignments', () => {

--- a/test/functionality/dataflow/processing-of-elements/atomic/dataflow-atomic.test.ts
+++ b/test/functionality/dataflow/processing-of-elements/atomic/dataflow-atomic.test.ts
@@ -91,6 +91,19 @@ describe.sequential('Atomic (dataflow information)', withShell(shell => {
 					.constant(4)
 
 			);
+			assertDataflow(label('chained dollar', ['name-normal', 'numbers', 'single-bracket-access']), shell,
+				'a$b$c', emptyGraph()
+					.use(0, 'a', { cds: [] })
+					.argument(3, 0)
+					.call(3, '$', [argumentInCall(0), argumentInCall(1)], { returns: [0], reads: [BuiltIn, 0, 1], onlyBuiltIn: true })
+					.argument(3, 1)
+					.argument(6, 3)
+					.call(6, '$', [argumentInCall(3), argumentInCall(4)], { returns: [3], reads: [3, 4, BuiltIn], onlyBuiltIn: true })
+					.argument(6, 4)
+					.constant(1)
+					.constant(4)
+
+			);
 			assertDataflow(label('chained mixed constant', ['dollar-access', 'single-bracket-access', 'name-normal', 'numbers']), shell,
 				'a[2]$a', emptyGraph()
 					.use(0, 'a', { cds: [] })
@@ -119,6 +132,13 @@ describe.sequential('Atomic (dataflow information)', withShell(shell => {
 			'a[x] <- 5',  emptyGraph()
 				.use(1, 'x')
 				.call(3, '[<-', [argumentInCall(0), argumentInCall(1), argumentInCall(4)], { returns: [0], reads: [1, BuiltIn], onlyBuiltIn: true })
+				.constant(4)
+				.defineVariable(0, 'a', { definedBy: [4, 3] })
+		);
+		assertDataflow(label('nested assign', ['name-normal', 'dollar-access', ...OperatorDatabase['<-'].capabilities, 'replacement-functions']), shell,
+			'a$b$c <- 5',  emptyGraph()
+				.use(1, 'x')
+				.call(3, '$<-', [argumentInCall(0), argumentInCall(1), argumentInCall(4)], { returns: [0], reads: [1, BuiltIn], onlyBuiltIn: true })
 				.constant(4)
 				.defineVariable(0, 'a', { definedBy: [4, 3] })
 		);

--- a/test/functionality/r-bridge/lang/ast/parse-access.test.ts
+++ b/test/functionality/r-bridge/lang/ast/parse-access.test.ts
@@ -486,6 +486,60 @@ describe.sequential('Parse value access', withShell(shell => {
 				}]
 			})
 		);
+		assertAst(label('Nested Access', ['name-normal', 'dollar-access']),
+			shell, 'c$x$y', exprList({
+				type:     RType.Access,
+				location: rangeFrom(1, 4, 1, 4),
+				lexeme:   '$',
+				operator: '$',
+				info:     {},
+				accessed: {
+					type:     RType.Access,
+					location: rangeFrom(1, 2, 1, 2),
+					lexeme:   '$',
+					operator: '$',
+					info:     {},
+					accessed: {
+						type:      RType.Symbol,
+						location:  rangeFrom(1, 1, 1, 1),
+						namespace: undefined,
+						lexeme:    'c',
+						content:   'c',
+						info:      {}
+					},
+					access: [{
+						type:     RType.Argument,
+						location: rangeFrom(1, 3, 1, 3),
+						lexeme:   'x',
+						name:     undefined,
+						info:     {},
+						value:    {
+							type:      RType.Symbol,
+							location:  rangeFrom(1, 3, 1, 3),
+							namespace: undefined,
+							lexeme:    'x',
+							content:   'x',
+							info:      {}
+						}
+					}]
+				},
+				access: [{
+					type:     RType.Argument,
+					location: rangeFrom(1, 5, 1, 5),
+					lexeme:   'y',
+					name:     undefined,
+					info:     {},
+					value:    {
+						type:      RType.Symbol,
+						location:  rangeFrom(1, 5, 1, 5),
+						namespace: undefined,
+						lexeme:    'y',
+						content:   'y',
+						info:      {}
+					}
+				}]
+			})
+		);
 		assertAst(label('Slot based access', ['name-normal', 'slot-access']),
 			shell, 'd@y', exprList({
 				type:     RType.Access,

--- a/test/functionality/slicing/pointer-analysis/container-single-index-based-access.test.ts
+++ b/test/functionality/slicing/pointer-analysis/container-single-index-based-access.test.ts
@@ -214,7 +214,7 @@ print(${acc('numbers', 1)})`
 			});
 		});
 
-		describe('Config flag', () => {
+		describe('Disable config flag (pointer tracking)', () => {
 			useConfigForTest({ solver: { pointerTracking: false } });
 
 			assertSliced(

--- a/test/functionality/slicing/static-program-slices/access.test.ts
+++ b/test/functionality/slicing/static-program-slices/access.test.ts
@@ -6,13 +6,21 @@ import { MIN_VERSION_PIPE } from '../../../../src/r-bridge/lang-4.x/ast/model/ve
 
 describe.sequential('dollar access', withShell(shell => {
 	describe('problems in practice', () => {
-	/* in this case, we assume that it may have an impact! */
+		/* in this case, we assume that it may have an impact! */
 		assertSliced(label('access addition', ['name-normal', ...OperatorDatabase['<-'].capabilities, ...OperatorDatabase['+'].capabilities, 'dollar-access', 'newlines']),
 			shell, `
 cor <- t$estimate
 pv <- t$p.value
 print(cor + pv)
 		`, ['4@print'], 'cor <- t$estimate\npv <- t$p.value\nprint(cor + pv)');
+
+		assertSliced(label('nested access', ['name-normal', ...OperatorDatabase['<-'].capabilities, ...OperatorDatabase['+'].capabilities, 'dollar-access', 'newlines']),
+			shell, `
+person <- list(name = list(a = list(b = "Jane")))
+person$name$a$b <- "John"
+print(person)
+		`, ['4@print'], 'person <- list(name = list(a = list(b = "Jane")))\nperson$name$a$b <- "John"\nprint(person)');
+
 
 		for(const pipe of ['%>%', '|>']) {
 			const code = `


### PR DESCRIPTION
Before PA this should have been fixable just by allowing recursive resolves of `$<-` and I think this was simply lost when rewriting the built-in environment to use the json config format. Now, with pointer analysis, we require much more sparkles.