### PR TITLE
Remove singleton config instance

### DIFF
--- a/src/benchmark/slicer.ts
+++ b/src/benchmark/slicer.ts
@@ -24,7 +24,7 @@ import type {
 } from './stats/stats';
 import type { NormalizedAst } from '../r-bridge/lang-4.x/ast/model/processing/decorate';
 import type { SlicingCriteria } from '../slicing/criterion/parse';
-import type { TREE_SITTER_SLICING_PIPELINE, DEFAULT_SLICING_PIPELINE } from '../core/steps/pipeline/default-pipelines';
+import type { DEFAULT_SLICING_PIPELINE, TREE_SITTER_SLICING_PIPELINE } from '../core/steps/pipeline/default-pipelines';
 import { createSlicePipeline } from '../core/steps/pipeline/default-pipelines';
 
 
@@ -135,7 +135,7 @@ export class BenchmarkSlicer {
 				if(this.parserName === 'r-shell') {
 					return new RShell(getEngineConfig(config, 'r-shell'));
 				} else {
-					await TreeSitterExecutor.initTreeSitter(config);
+					await TreeSitterExecutor.initTreeSitter(getEngineConfig(config, 'tree-sitter'));
 					return new TreeSitterExecutor();
 				}
 			}

--- a/src/benchmark/summarizer/first-phase/process.ts
+++ b/src/benchmark/summarizer/first-phase/process.ts
@@ -15,6 +15,7 @@ import { retrieveNormalizedAstFromRCode, retrieveNumberOfRTokensOfLastParse } fr
 import { visitAst } from '../../../r-bridge/lang-4.x/ast/model/processing/visitor';
 import { RType } from '../../../r-bridge/lang-4.x/ast/model/type';
 import { arraySum } from '../../../util/collections/arrays';
+import type { RShellEngineConfig } from '../../../config';
 
 const tempfile = (() => {
 	let _tempfile: tmp.FileResult | undefined = undefined;
@@ -76,10 +77,12 @@ function calculateReductionForSlice(input: SlicerStatsInput, dataflow: SlicerSta
 export async function summarizeSlicerStats(
 	stats: SlicerStats,
 	report: (criteria: SlicingCriteria, stats: PerSliceStats) => void = () => { /* do nothing */
-	}): Promise<Readonly<SummarizedSlicerStats>> {
+	},
+	engineConf?: RShellEngineConfig,
+): Promise<Readonly<SummarizedSlicerStats>> {
 	const collect = new DefaultMap<PerSliceMeasurements, number[]>(() => []);
 	const sizeOfSliceCriteria: number[] = [];
-	const reParseShellSession = new RShell();
+	const reParseShellSession = new RShell(engineConf);
 
 	const sliceTimes: TimePerToken<number>[] = [];
 	const reconstructTimes: TimePerToken<number>[] = [];

--- a/src/cli/benchmark-helper-app.ts
+++ b/src/cli/benchmark-helper-app.ts
@@ -59,7 +59,7 @@ async function benchmark() {
 	}
 
 	// Enable pointer analysis if requested, otherwise disable it
-	let config = getConfig(undefined);
+	let config = getConfig();
 	if(options['enable-pointer-tracking']) {
 		config = amendConfig(config, { solver: { ...config.solver, pointerTracking: true, } });
 	} else {

--- a/src/cli/benchmark-helper-app.ts
+++ b/src/cli/benchmark-helper-app.ts
@@ -59,11 +59,11 @@ async function benchmark() {
 	}
 
 	// Enable pointer analysis if requested, otherwise disable it
-	const config = getConfig(undefined);
+	let config = getConfig(undefined);
 	if(options['enable-pointer-tracking']) {
-		amendConfig(config, { solver: { ...config.solver, pointerTracking: true, } });
+		config = amendConfig(config, { solver: { ...config.solver, pointerTracking: true, } });
 	} else {
-		amendConfig(config, { solver: { ...config.solver, pointerTracking: false, } });
+		config = amendConfig(config, { solver: { ...config.solver, pointerTracking: false, } });
 	}
 
 	// ensure the file exists
@@ -75,7 +75,7 @@ async function benchmark() {
 	const maxSlices = options['max-slices'] ?? -1;
 	const slicer = new BenchmarkSlicer(options.parser);
 	try {
-		await slicer.init(request, undefined, options.threshold);
+		await slicer.init(request, config, undefined, options.threshold);
 
 		// ${escape}1F${escape}1G${escape}2K for line reset
 		if(options.slice === 'all') {

--- a/src/cli/benchmark-helper-app.ts
+++ b/src/cli/benchmark-helper-app.ts
@@ -59,10 +59,11 @@ async function benchmark() {
 	}
 
 	// Enable pointer analysis if requested, otherwise disable it
+	const config = getConfig(undefined);
 	if(options['enable-pointer-tracking']) {
-		amendConfig({ solver: { ...getConfig().solver, pointerTracking: true, } });
+		amendConfig(config, { solver: { ...config.solver, pointerTracking: true, } });
 	} else {
-		amendConfig({ solver: { ...getConfig().solver, pointerTracking: false, } });
+		amendConfig(config, { solver: { ...config.solver, pointerTracking: false, } });
 	}
 
 	// ensure the file exists

--- a/src/cli/export-quads-app.ts
+++ b/src/cli/export-quads-app.ts
@@ -24,7 +24,7 @@ const options = processCommandLineArgs<QuadsCliOptions>('export-quads', [],{
 	]
 });
 
-const shell = new RShell(getEngineConfig(getConfig(undefined), 'r-shell'));
+const shell = new RShell(getEngineConfig(getConfig(), 'r-shell'));
 
 async function writeQuadForSingleFile(request: RParseRequestFromFile, output: string) {
 	const normalized = await retrieveNormalizedAstFromRCode(request, shell);

--- a/src/cli/export-quads-app.ts
+++ b/src/cli/export-quads-app.ts
@@ -6,6 +6,7 @@ import { processCommandLineArgs } from './common/script';
 import { RShell } from '../r-bridge/shell';
 import type { RParseRequestFromFile } from '../r-bridge/retriever';
 import { retrieveNormalizedAstFromRCode } from '../r-bridge/retriever';
+import { getConfig, getEngineConfig } from '../config';
 
 export interface QuadsCliOptions {
 	verbose: boolean
@@ -23,7 +24,7 @@ const options = processCommandLineArgs<QuadsCliOptions>('export-quads', [],{
 	]
 });
 
-const shell = new RShell();
+const shell = new RShell(getEngineConfig(getConfig(undefined), 'r-shell'));
 
 async function writeQuadForSingleFile(request: RParseRequestFromFile, output: string) {
 	const normalized = await retrieveNormalizedAstFromRCode(request, shell);

--- a/src/cli/flowr.ts
+++ b/src/cli/flowr.ts
@@ -14,7 +14,7 @@ import { log, LogLevel } from '../util/log';
 import { bold, ColorEffect, Colors, FontStyles, formatter, italic, setFormatter, voidFormatter } from '../util/text/ansi';
 import commandLineArgs from 'command-line-args';
 import type { EngineConfig, FlowrConfigOptions, KnownEngines } from '../config';
-import { getConfig , amendConfig, getEngineConfig, parseConfig } from '../config';
+import { amendConfig, getConfig, getEngineConfig, parseConfig } from '../config';
 import { guard } from '../util/assert';
 import type { ScriptInformation } from './common/scripts-info';
 import { scripts } from './common/scripts-info';
@@ -149,7 +149,7 @@ async function retrieveEngineInstances(config: FlowrConfigOptions): Promise<{ en
 		});
 	}
 	if(getEngineConfig(config, 'tree-sitter')) {
-		await TreeSitterExecutor.initTreeSitter(config);
+		await TreeSitterExecutor.initTreeSitter(getEngineConfig(config, 'tree-sitter'));
 		engines['tree-sitter'] = new TreeSitterExecutor();
 	}
 	let defaultEngine = config.defaultEngine;
@@ -217,7 +217,7 @@ async function mainServer(backend: Server = new NetServer()) {
 	const config = createConfig();
 	const engines = await retrieveEngineInstances(config);
 	hookSignalHandlers(engines);
-	await new FlowRServer(config, engines.engines, engines.default, options['r-session-access'], backend).start(options.port);
+	await new FlowRServer(engines.engines, engines.default, options['r-session-access'], config, backend).start(options.port);
 }
 
 

--- a/src/cli/flowr.ts
+++ b/src/cli/flowr.ts
@@ -217,7 +217,7 @@ async function mainServer(backend: Server = new NetServer()) {
 	const config = createConfig();
 	const engines = await retrieveEngineInstances(config);
 	hookSignalHandlers(engines);
-	await new FlowRServer(engines.engines, engines.default, options['r-session-access'], backend).start(options.port);
+	await new FlowRServer(config, engines.engines, engines.default, options['r-session-access'], backend).start(options.port);
 }
 
 

--- a/src/cli/flowr.ts
+++ b/src/cli/flowr.ts
@@ -13,8 +13,8 @@ import commandLineUsage from 'command-line-usage';
 import { log, LogLevel } from '../util/log';
 import { bold, ColorEffect, Colors, FontStyles, formatter, italic, setFormatter, voidFormatter } from '../util/text/ansi';
 import commandLineArgs from 'command-line-args';
-import type { EngineConfig, KnownEngines } from '../config';
-import { getConfig ,   amendConfig, getEngineConfig, parseConfig, setConfig, setConfigFile } from '../config';
+import type { EngineConfig, FlowrConfigOptions, KnownEngines } from '../config';
+import { getConfig , amendConfig, getEngineConfig, parseConfig } from '../config';
 import { guard } from '../util/assert';
 import type { ScriptInformation } from './common/scripts-info';
 import { scripts } from './common/scripts-info';
@@ -88,45 +88,56 @@ if(options['no-ansi']) {
 	setFormatter(voidFormatter);
 }
 
-let usedConfig = false;
-if(options['config-json']) {
-	const config = parseConfig(options['config-json']);
-	if(config) {
-		log.info(`Using passed config ${JSON.stringify(config)}`);
-		setConfig(config);
-		usedConfig = true;
-	}
-}
-if(!usedConfig) {
-	if(options['config-file']) {
-		// validate it exists
-		if(!fs.existsSync(path.resolve(options['config-file']))) {
-			log.error(`Config file '${options['config-file']}' does not exist`);
-			process.exit(1);
+function createConfig() : FlowrConfigOptions {
+	let config: FlowrConfigOptions | undefined;
+
+	if(options['config-json']) {
+		const passedConfig = parseConfig(options['config-json']);
+		if(passedConfig) {
+			log.info(`Using passed config ${JSON.stringify(passedConfig)}`);
+			config = passedConfig;
 		}
 	}
-	setConfigFile(options['config-file'] ?? defaultConfigFile, undefined, true);
+	if(config == undefined) {
+		if(options['config-file']) {
+			// validate it exists
+			if(!fs.existsSync(path.resolve(options['config-file']))) {
+				log.error(`Config file '${options['config-file']}' does not exist`);
+				process.exit(1);
+			}
+		}
+		config = getConfig(options['config-file'] ?? defaultConfigFile);
+	}
+
+	// for all options that we manually supply that have a config equivalent, set them in the config
+	if(!options['engine.r-shell.disabled']) {
+		config = amendConfig(config, {
+			engines: [{
+				type:  'r-shell',
+				rPath: options['r-path'] || options['engine.r-shell.r-path']
+			}]
+		});
+	}
+	if(!options['engine.tree-sitter.disabled']) {
+		config = amendConfig(config, {
+			engines: [{
+				type:               'tree-sitter',
+				wasmPath:           options['engine.tree-sitter.wasm-path'],
+				treeSitterWasmPath: options['engine.tree-sitter.tree-sitter-wasm-path'],
+				lax:                options['engine.tree-sitter.lax']
+			}]
+		});
+	}
+	if(options['default-engine']) {
+		config = amendConfig(config, { defaultEngine: options['default-engine'] as EngineConfig['type'] });
+	}
+	return config;
 }
 
-// for all options that we manually supply that have a config equivalent, set them in the config
-if(!options['engine.r-shell.disabled']) {
-	amendConfig({ engines: [{ type: 'r-shell', rPath: options['r-path'] || options['engine.r-shell.r-path'] }] });
-}
-if(!options['engine.tree-sitter.disabled']){
-	amendConfig({ engines: [{
-		type:               'tree-sitter',
-		wasmPath:           options['engine.tree-sitter.wasm-path'],
-		treeSitterWasmPath: options['engine.tree-sitter.tree-sitter-wasm-path'],
-		lax:                options['engine.tree-sitter.lax']
-	}] });
-}
-if(options['default-engine']) {
-	amendConfig({ defaultEngine: options['default-engine'] as EngineConfig['type'] });
-}
 
-async function retrieveEngineInstances(): Promise<{ engines: KnownEngines, default: keyof KnownEngines }> {
+async function retrieveEngineInstances(config: FlowrConfigOptions): Promise<{ engines: KnownEngines, default: keyof KnownEngines }> {
 	const engines: KnownEngines = {};
-	if(getEngineConfig('r-shell')) {
+	if(getEngineConfig(config, 'r-shell')) {
 		// we keep an active shell session to allow other parse investigations :)
 		engines['r-shell'] = new RShell({
 			revive:   RShellReviveOptions.Always,
@@ -137,11 +148,11 @@ async function retrieveEngineInstances(): Promise<{ engines: KnownEngines, defau
 			}
 		});
 	}
-	if(getEngineConfig('tree-sitter')) {
+	if(getEngineConfig(config, 'tree-sitter')) {
 		await TreeSitterExecutor.initTreeSitter();
 		engines['tree-sitter'] = new TreeSitterExecutor();
 	}
-	let defaultEngine = getConfig().defaultEngine;
+	let defaultEngine = config.defaultEngine;
 	if(!defaultEngine || !engines[defaultEngine]) {
 		// if a default engine isn't specified, we just take the first one we have
 		defaultEngine = Object.keys(engines)[0] as keyof KnownEngines;
@@ -150,7 +161,22 @@ async function retrieveEngineInstances(): Promise<{ engines: KnownEngines, defau
 	return { engines, default: defaultEngine };
 }
 
+function hookSignalHandlers(engines: { engines: KnownEngines; default: keyof KnownEngines }) {
+	const end = () => {
+		if(options.execute === undefined) {
+			console.log(`\n${italic('Exiting...')}`);
+		}
+		Object.values(engines.engines).forEach(e => e?.close());
+		process.exit(0);
+	};
+
+	process.on('SIGINT', end);
+	process.on('SIGTERM', end);
+}
+
 async function mainRepl() {
+	const config = createConfig();
+
 	if(options.script) {
 		const target = (scripts as DeepReadonly<Record<string, ScriptInformation>>)[options.script].target as string | undefined;
 		guard(target !== undefined, `Unknown script ${options.script}, pick one of ${getScriptsText()}.`);
@@ -165,7 +191,7 @@ async function mainRepl() {
 		process.exit(0);
 	}
 
-	const engines = await retrieveEngineInstances();
+	const engines = await retrieveEngineInstances(config);
 	const defaultEngine = engines.engines[engines.default] as KnownParser;
 
 	if(options.version) {
@@ -175,18 +201,7 @@ async function mainRepl() {
 		}
 		process.exit(0);
 	}
-
-	const end = () => {
-		if(options.execute === undefined) {
-			console.log(`\n${italic('Exiting...')}`);
-		}
-		Object.values(engines.engines).forEach(e => e?.close());
-		process.exit(0);
-	};
-
-	// hook some handlers
-	process.on('SIGINT', end);
-	process.on('SIGTERM', end);
+	hookSignalHandlers(engines);
 
 	const allowRSessionAccess = options['r-session-access'] ?? false;
 	if(options.execute) {
@@ -199,19 +214,9 @@ async function mainRepl() {
 }
 
 async function mainServer(backend: Server = new NetServer()) {
-	const engines = await retrieveEngineInstances();
-
-	const end = () => {
-		if(options.execute === undefined) {
-			console.log(`\n${italic('Exiting...')}`);
-		}
-		Object.values(engines.engines).forEach(e => e?.close());
-		process.exit(0);
-	};
-
-	// hook some handlers
-	process.on('SIGINT', end);
-	process.on('SIGTERM', end);
+	const config = createConfig();
+	const engines = await retrieveEngineInstances(config);
+	hookSignalHandlers(engines);
 	await new FlowRServer(engines.engines, engines.default, options['r-session-access'], backend).start(options.port);
 }
 

--- a/src/cli/flowr.ts
+++ b/src/cli/flowr.ts
@@ -139,7 +139,7 @@ async function retrieveEngineInstances(config: FlowrConfigOptions): Promise<{ en
 	const engines: KnownEngines = {};
 	if(getEngineConfig(config, 'r-shell')) {
 		// we keep an active shell session to allow other parse investigations :)
-		engines['r-shell'] = new RShell({
+		engines['r-shell'] = new RShell(getEngineConfig(config, 'r-shell'), {
 			revive:   RShellReviveOptions.Always,
 			onRevive: (code, signal) => {
 				const signalText = signal == null ? '' : ` and signal ${signal}`;
@@ -149,7 +149,7 @@ async function retrieveEngineInstances(config: FlowrConfigOptions): Promise<{ en
 		});
 	}
 	if(getEngineConfig(config, 'tree-sitter')) {
-		await TreeSitterExecutor.initTreeSitter();
+		await TreeSitterExecutor.initTreeSitter(config);
 		engines['tree-sitter'] = new TreeSitterExecutor();
 	}
 	let defaultEngine = config.defaultEngine;

--- a/src/cli/flowr.ts
+++ b/src/cli/flowr.ts
@@ -205,10 +205,10 @@ async function mainRepl() {
 
 	const allowRSessionAccess = options['r-session-access'] ?? false;
 	if(options.execute) {
-		await replProcessAnswer(standardReplOutput, options.execute, defaultEngine, allowRSessionAccess);
+		await replProcessAnswer(config, standardReplOutput, options.execute, defaultEngine, allowRSessionAccess);
 	} else {
 		await printVersionRepl(defaultEngine);
-		await repl({ parser: defaultEngine, allowRSessionAccess });
+		await repl(config, { parser: defaultEngine, allowRSessionAccess });
 	}
 	process.exit(0);
 }

--- a/src/cli/repl/commands/repl-cfg.ts
+++ b/src/cli/repl/commands/repl-cfg.ts
@@ -5,11 +5,12 @@ import { fileProtocol, requestFromInput } from '../../../r-bridge/retriever';
 import { cfgToMermaid, cfgToMermaidUrl } from '../../../util/mermaid/cfg';
 import type { KnownParser } from '../../../r-bridge/parser';
 import { ColorEffect, Colors, FontStyles } from '../../../util/text/ansi';
+import type { FlowrConfigOptions } from '../../../config';
 
-async function controlflow(parser: KnownParser, remainingLine: string) {
+async function controlflow(parser: KnownParser, remainingLine: string, config: FlowrConfigOptions) {
 	return await createDataflowPipeline(parser, {
 		request: requestFromInput(remainingLine.trim())
-	}).allRemainingSteps();
+	}, config).allRemainingSteps();
 }
 
 function handleString(code: string): string {
@@ -25,8 +26,8 @@ export const controlflowCommand: ReplCommand = {
 	usageExample: ':controlflow',
 	aliases:      [ 'cfg', 'cf' ],
 	script:       false,
-	fn:           async(output, shell, remainingLine) => {
-		const result = await controlflow(shell, handleString(remainingLine));
+	fn:           async(config, output, shell, remainingLine) => {
+		const result = await controlflow(shell, handleString(remainingLine), config);
 
 		const cfg = extractCFG(result.normalize, result.dataflow.graph);
 		const mermaid = cfgToMermaid(cfg, result.normalize);
@@ -44,8 +45,8 @@ export const controlflowStarCommand: ReplCommand = {
 	usageExample: ':controlflow*',
 	aliases:      [ 'cfg*', 'cf*' ],
 	script:       false,
-	fn:           async(output, shell, remainingLine) => {
-		const result = await controlflow(shell, handleString(remainingLine));
+	fn:           async(config, output, shell, remainingLine) => {
+		const result = await controlflow(shell, handleString(remainingLine), config);
 
 		const cfg = extractCFG(result.normalize, result.dataflow.graph);
 		const mermaid = cfgToMermaidUrl(cfg, result.normalize);

--- a/src/cli/repl/commands/repl-cfg.ts
+++ b/src/cli/repl/commands/repl-cfg.ts
@@ -26,7 +26,7 @@ export const controlflowCommand: ReplCommand = {
 	usageExample: ':controlflow',
 	aliases:      [ 'cfg', 'cf' ],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
+	fn:           async(output, shell, remainingLine, _, config) => {
 		const result = await controlflow(shell, handleString(remainingLine), config);
 
 		const cfg = extractCFG(result.normalize, result.dataflow.graph);
@@ -45,7 +45,7 @@ export const controlflowStarCommand: ReplCommand = {
 	usageExample: ':controlflow*',
 	aliases:      [ 'cfg*', 'cf*' ],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
+	fn:           async(output, shell, remainingLine, _, config) => {
 		const result = await controlflow(shell, handleString(remainingLine), config);
 
 		const cfg = extractCFG(result.normalize, result.dataflow.graph);

--- a/src/cli/repl/commands/repl-commands.ts
+++ b/src/cli/repl/commands/repl-commands.ts
@@ -52,7 +52,7 @@ export const helpCommand: ReplCommand = {
 	script:       false,
 	usageExample: ':help',
 	aliases:      [ 'h', '?' ],
-	fn:           (_config, output) => {
+	fn:           (output) => {
 		initCommandMapping();
 		output.stdout(`
 If enabled ('--r-session-access'), you can just enter R expressions which get evaluated right away:
@@ -120,7 +120,7 @@ export function getReplCommands() {
 				aliases:      [],
 				script:       true,
 				usageExample: `:${script} --help`,
-				fn:           async(_config, output, _s, remainingLine) => {
+				fn:           async(output, _s, remainingLine) => {
 					// check if the target *module* exists in the current directory, else try two dirs up, otherwise, fail with a message
 					let path = `${__dirname}/${target}`;
 					if(!hasModule(path)) {

--- a/src/cli/repl/commands/repl-commands.ts
+++ b/src/cli/repl/commands/repl-commands.ts
@@ -52,7 +52,7 @@ export const helpCommand: ReplCommand = {
 	script:       false,
 	usageExample: ':help',
 	aliases:      [ 'h', '?' ],
-	fn:           output => {
+	fn:           (_config, output) => {
 		initCommandMapping();
 		output.stdout(`
 If enabled ('--r-session-access'), you can just enter R expressions which get evaluated right away:
@@ -120,7 +120,7 @@ export function getReplCommands() {
 				aliases:      [],
 				script:       true,
 				usageExample: `:${script} --help`,
-				fn:           async(output, _s, remainingLine) => {
+				fn:           async(_config, output, _s, remainingLine) => {
 					// check if the target *module* exists in the current directory, else try two dirs up, otherwise, fail with a message
 					let path = `${__dirname}/${target}`;
 					if(!hasModule(path)) {

--- a/src/cli/repl/commands/repl-dataflow.ts
+++ b/src/cli/repl/commands/repl-dataflow.ts
@@ -4,14 +4,15 @@ import { fileProtocol, requestFromInput } from '../../../r-bridge/retriever';
 import { graphToMermaid, graphToMermaidUrl } from '../../../util/mermaid/dfg';
 import type { KnownParser } from '../../../r-bridge/parser';
 import { ColorEffect, Colors, FontStyles } from '../../../util/text/ansi';
+import {FlowrConfigOptions} from "../../../config";
 
 /**
  * Obtain the dataflow graph using a known parser (such as the {@link RShell} or {@link TreeSitterExecutor}).
  */
-async function replGetDataflow(parser: KnownParser, code: string) {
+async function replGetDataflow(config: FlowrConfigOptions, parser: KnownParser, code: string) {
 	return await createDataflowPipeline(parser, {
 		request: requestFromInput(code.trim())
-	}).allRemainingSteps();
+	}, config).allRemainingSteps();
 }
 
 function handleString(code: string): string {
@@ -27,8 +28,8 @@ export const dataflowCommand: ReplCommand = {
 	usageExample: ':dataflow',
 	aliases:      [ 'd', 'df' ],
 	script:       false,
-	fn:           async(output, shell, remainingLine) => {
-		const result = await replGetDataflow(shell, handleString(remainingLine));
+	fn:           async(config, output, shell, remainingLine) => {
+		const result = await replGetDataflow(config, shell, handleString(remainingLine));
 		const mermaid = graphToMermaid({ graph: result.dataflow.graph, includeEnvironments: false }).string;
 		output.stdout(mermaid);
 		try {
@@ -44,8 +45,8 @@ export const dataflowStarCommand: ReplCommand = {
 	usageExample: ':dataflow*',
 	aliases:      [ 'd*', 'df*' ],
 	script:       false,
-	fn:           async(output, shell, remainingLine) => {
-		const result = await replGetDataflow(shell, handleString(remainingLine));
+	fn:           async(config, output, shell, remainingLine) => {
+		const result = await replGetDataflow(config, shell, handleString(remainingLine));
 		const mermaid = graphToMermaidUrl(result.dataflow.graph, false);
 		output.stdout(mermaid);
 		try {
@@ -62,8 +63,8 @@ export const dataflowSimplifiedCommand: ReplCommand = {
 	usageExample: ':dataflowsimple',
 	aliases:      [ 'ds', 'dfs' ],
 	script:       false,
-	fn:           async(output, shell, remainingLine) => {
-		const result = await replGetDataflow(shell, handleString(remainingLine));
+	fn:           async(config, output, shell, remainingLine) => {
+		const result = await replGetDataflow(config, shell, handleString(remainingLine));
 		const mermaid = graphToMermaid({ graph: result.dataflow.graph, includeEnvironments: false, simplified: true }).string;
 		output.stdout(mermaid);
 		try {
@@ -79,8 +80,8 @@ export const dataflowSimpleStarCommand: ReplCommand = {
 	usageExample: ':dataflowsimple*',
 	aliases:      [ 'ds*', 'dfs*' ],
 	script:       false,
-	fn:           async(output, shell, remainingLine) => {
-		const result = await replGetDataflow(shell, handleString(remainingLine));
+	fn:           async(config, output, shell, remainingLine) => {
+		const result = await replGetDataflow(config, shell, handleString(remainingLine));
 		const mermaid = graphToMermaidUrl(result.dataflow.graph, false, undefined, true);
 		output.stdout(mermaid);
 		try {

--- a/src/cli/repl/commands/repl-dataflow.ts
+++ b/src/cli/repl/commands/repl-dataflow.ts
@@ -4,7 +4,7 @@ import { fileProtocol, requestFromInput } from '../../../r-bridge/retriever';
 import { graphToMermaid, graphToMermaidUrl } from '../../../util/mermaid/dfg';
 import type { KnownParser } from '../../../r-bridge/parser';
 import { ColorEffect, Colors, FontStyles } from '../../../util/text/ansi';
-import {FlowrConfigOptions} from "../../../config";
+import type { FlowrConfigOptions } from '../../../config';
 
 /**
  * Obtain the dataflow graph using a known parser (such as the {@link RShell} or {@link TreeSitterExecutor}).
@@ -28,7 +28,7 @@ export const dataflowCommand: ReplCommand = {
 	usageExample: ':dataflow',
 	aliases:      [ 'd', 'df' ],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
+	fn:           async(output, shell, remainingLine, _, config) => {
 		const result = await replGetDataflow(config, shell, handleString(remainingLine));
 		const mermaid = graphToMermaid({ graph: result.dataflow.graph, includeEnvironments: false }).string;
 		output.stdout(mermaid);
@@ -45,7 +45,7 @@ export const dataflowStarCommand: ReplCommand = {
 	usageExample: ':dataflow*',
 	aliases:      [ 'd*', 'df*' ],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
+	fn:           async(output, shell, remainingLine, _, config) => {
 		const result = await replGetDataflow(config, shell, handleString(remainingLine));
 		const mermaid = graphToMermaidUrl(result.dataflow.graph, false);
 		output.stdout(mermaid);
@@ -63,7 +63,7 @@ export const dataflowSimplifiedCommand: ReplCommand = {
 	usageExample: ':dataflowsimple',
 	aliases:      [ 'ds', 'dfs' ],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
+	fn:           async(output, shell, remainingLine, _, config) => {
 		const result = await replGetDataflow(config, shell, handleString(remainingLine));
 		const mermaid = graphToMermaid({ graph: result.dataflow.graph, includeEnvironments: false, simplified: true }).string;
 		output.stdout(mermaid);
@@ -80,7 +80,7 @@ export const dataflowSimpleStarCommand: ReplCommand = {
 	usageExample: ':dataflowsimple*',
 	aliases:      [ 'ds*', 'dfs*' ],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
+	fn:           async(output, shell, remainingLine, _, config) => {
 		const result = await replGetDataflow(config, shell, handleString(remainingLine));
 		const mermaid = graphToMermaidUrl(result.dataflow.graph, false, undefined, true);
 		output.stdout(mermaid);

--- a/src/cli/repl/commands/repl-execute.ts
+++ b/src/cli/repl/commands/repl-execute.ts
@@ -4,7 +4,7 @@ import { RShell } from '../../../r-bridge/shell';
 import type { KnownParser } from '../../../r-bridge/parser';
 import type { FlowrConfigOptions } from '../../../config';
 
-export async function tryExecuteRShellCommand(_config: FlowrConfigOptions, output: ReplOutput, parser: KnownParser, statement: string, allowRSessionAccess: boolean) {
+export async function tryExecuteRShellCommand(output: ReplOutput, parser: KnownParser, statement: string, allowRSessionAccess: boolean, _config: FlowrConfigOptions) {
 	if(!allowRSessionAccess){
 		output.stderr(`${output.formatter.format('You are not allowed to execute arbitrary R code.', { style: FontStyles.Bold, color: Colors.Red, effect: ColorEffect.Foreground })}\nIf you want to do so, please restart flowR with the ${output.formatter.format('--r-session-access', { style: FontStyles.Bold })} flag. Please be careful of the security implications of this action.`);
 	} else if(parser instanceof RShell) {

--- a/src/cli/repl/commands/repl-execute.ts
+++ b/src/cli/repl/commands/repl-execute.ts
@@ -2,8 +2,9 @@ import type { ReplCommand, ReplOutput } from './repl-main';
 import { ColorEffect, Colors, FontStyles, italic } from '../../../util/text/ansi';
 import { RShell } from '../../../r-bridge/shell';
 import type { KnownParser } from '../../../r-bridge/parser';
+import type { FlowrConfigOptions } from '../../../config';
 
-export async function tryExecuteRShellCommand(output: ReplOutput, parser: KnownParser, statement: string, allowRSessionAccess: boolean) {
+export async function tryExecuteRShellCommand(_config: FlowrConfigOptions, output: ReplOutput, parser: KnownParser, statement: string, allowRSessionAccess: boolean) {
 	if(!allowRSessionAccess){
 		output.stderr(`${output.formatter.format('You are not allowed to execute arbitrary R code.', { style: FontStyles.Bold, color: Colors.Red, effect: ColorEffect.Foreground })}\nIf you want to do so, please restart flowR with the ${output.formatter.format('--r-session-access', { style: FontStyles.Bold })} flag. Please be careful of the security implications of this action.`);
 	} else if(parser instanceof RShell) {

--- a/src/cli/repl/commands/repl-lineage.ts
+++ b/src/cli/repl/commands/repl-lineage.ts
@@ -70,7 +70,7 @@ export const lineageCommand: ReplCommand = {
 	usageExample: ':lineage',
 	aliases:      ['lin'],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
+	fn:           async(output, shell, remainingLine, _, config) => {
 		const [criterion, rest] = splitAt(remainingLine, remainingLine.indexOf(' '));
 		const { dataflow: dfg } = await getDfg(config, shell, rest);
 		const lineageIds = getLineage(criterion as SingleSlicingCriterion, dfg.graph);

--- a/src/cli/repl/commands/repl-lineage.ts
+++ b/src/cli/repl/commands/repl-lineage.ts
@@ -10,15 +10,16 @@ import { edgeIncludesType, EdgeType } from '../../../dataflow/graph/edge';
 import type { AstIdMap } from '../../../r-bridge/lang-4.x/ast/model/processing/decorate';
 import { guard } from '../../../util/assert';
 import type { KnownParser } from '../../../r-bridge/parser';
+import type { FlowrConfigOptions } from '../../../config';
 
 function splitAt(str: string, idx: number) {
 	return [str.slice(0, idx), str.slice(idx)];
 }
 
-async function getDfg(parser: KnownParser, remainingLine: string) {
+async function getDfg(config: FlowrConfigOptions, parser: KnownParser, remainingLine: string) {
 	return await createDataflowPipeline(parser, {
 		request: requestFromInput(remainingLine.trim())
-	}).allRemainingSteps();
+	}, config).allRemainingSteps();
 }
 
 function filterRelevantEdges(edge: DataflowGraphEdge) {
@@ -69,9 +70,9 @@ export const lineageCommand: ReplCommand = {
 	usageExample: ':lineage',
 	aliases:      ['lin'],
 	script:       false,
-	fn:           async(output, shell, remainingLine) => {
+	fn:           async(config, output, shell, remainingLine) => {
 		const [criterion, rest] = splitAt(remainingLine, remainingLine.indexOf(' '));
-		const { dataflow: dfg } = await getDfg(shell, rest);
+		const { dataflow: dfg } = await getDfg(config, shell, rest);
 		const lineageIds = getLineage(criterion as SingleSlicingCriterion, dfg.graph);
 		output.stdout([...lineageIds].join('\n'));
 	}

--- a/src/cli/repl/commands/repl-main.ts
+++ b/src/cli/repl/commands/repl-main.ts
@@ -1,6 +1,7 @@
 import type { OutputFormatter } from '../../../util/text/ansi';
 import { formatter } from '../../../util/text/ansi';
 import type { KnownParser } from '../../../r-bridge/parser';
+import {FlowrConfigOptions} from "../../../config";
 
 /**
  * Defines the main interface for output of the repl.
@@ -43,5 +44,5 @@ export interface ReplCommand {
 	 * Function to execute when the command is invoked, it must not write to the command line but instead use the output handler.
 	 * Furthermore, it has to obey the formatter defined in the {@link ReplOutput}.
 	 */
-	fn:           (output: ReplOutput, parser: KnownParser, remainingLine: string, allowRSessionAccess: boolean) => Promise<void> | void
+	fn:           (config: FlowrConfigOptions, output: ReplOutput, parser: KnownParser, remainingLine: string, allowRSessionAccess: boolean) => Promise<void> | void
 }

--- a/src/cli/repl/commands/repl-main.ts
+++ b/src/cli/repl/commands/repl-main.ts
@@ -1,7 +1,7 @@
 import type { OutputFormatter } from '../../../util/text/ansi';
 import { formatter } from '../../../util/text/ansi';
 import type { KnownParser } from '../../../r-bridge/parser';
-import {FlowrConfigOptions} from "../../../config";
+import type { FlowrConfigOptions } from '../../../config';
 
 /**
  * Defines the main interface for output of the repl.
@@ -44,5 +44,5 @@ export interface ReplCommand {
 	 * Function to execute when the command is invoked, it must not write to the command line but instead use the output handler.
 	 * Furthermore, it has to obey the formatter defined in the {@link ReplOutput}.
 	 */
-	fn:           (config: FlowrConfigOptions, output: ReplOutput, parser: KnownParser, remainingLine: string, allowRSessionAccess: boolean) => Promise<void> | void
+	fn:           (output: ReplOutput, parser: KnownParser, remainingLine: string, allowRSessionAccess: boolean, config: FlowrConfigOptions) => Promise<void> | void
 }

--- a/src/cli/repl/commands/repl-normalize.ts
+++ b/src/cli/repl/commands/repl-normalize.ts
@@ -4,11 +4,12 @@ import { fileProtocol, requestFromInput } from '../../../r-bridge/retriever';
 import { normalizedAstToMermaid, normalizedAstToMermaidUrl } from '../../../util/mermaid/ast';
 import type { KnownParser } from '../../../r-bridge/parser';
 import { ColorEffect, Colors, FontStyles } from '../../../util/text/ansi';
+import type { FlowrConfigOptions } from '../../../config';
 
-async function normalize(parser: KnownParser, remainingLine: string) {
+async function normalize(config: FlowrConfigOptions, parser: KnownParser, remainingLine: string) {
 	return await createNormalizePipeline(parser, {
 		request: requestFromInput(remainingLine.trim())
-	}).allRemainingSteps();
+	}, config).allRemainingSteps();
 }
 
 function handleString(code: string): string {
@@ -24,8 +25,8 @@ export const normalizeCommand: ReplCommand = {
 	usageExample: ':normalize',
 	aliases:      [ 'n' ],
 	script:       false,
-	fn:           async(output, shell, remainingLine) => {
-		const result = await normalize(shell, handleString(remainingLine));
+	fn:           async(config, output, shell, remainingLine) => {
+		const result = await normalize(config, shell, handleString(remainingLine));
 		const mermaid = normalizedAstToMermaid(result.normalize.ast);
 		output.stdout(mermaid);
 		try {
@@ -41,8 +42,8 @@ export const normalizeStarCommand: ReplCommand = {
 	usageExample: ':normalize*',
 	aliases:      [ 'n*' ],
 	script:       false,
-	fn:           async(output, shell, remainingLine) => {
-		const result = await normalize(shell, handleString(remainingLine));
+	fn:           async(config, output, shell, remainingLine) => {
+		const result = await normalize(config, shell, handleString(remainingLine));
 		const mermaid = normalizedAstToMermaidUrl(result.normalize.ast);
 		output.stdout(mermaid);
 		try {

--- a/src/cli/repl/commands/repl-normalize.ts
+++ b/src/cli/repl/commands/repl-normalize.ts
@@ -6,7 +6,7 @@ import type { KnownParser } from '../../../r-bridge/parser';
 import { ColorEffect, Colors, FontStyles } from '../../../util/text/ansi';
 import type { FlowrConfigOptions } from '../../../config';
 
-async function normalize(config: FlowrConfigOptions, parser: KnownParser, remainingLine: string) {
+async function normalize(parser: KnownParser, remainingLine: string, config: FlowrConfigOptions) {
 	return await createNormalizePipeline(parser, {
 		request: requestFromInput(remainingLine.trim())
 	}, config).allRemainingSteps();
@@ -25,8 +25,8 @@ export const normalizeCommand: ReplCommand = {
 	usageExample: ':normalize',
 	aliases:      [ 'n' ],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
-		const result = await normalize(config, shell, handleString(remainingLine));
+	fn:           async(output, shell, remainingLine, _, config) => {
+		const result = await normalize(shell, handleString(remainingLine), config);
 		const mermaid = normalizedAstToMermaid(result.normalize.ast);
 		output.stdout(mermaid);
 		try {
@@ -42,8 +42,8 @@ export const normalizeStarCommand: ReplCommand = {
 	usageExample: ':normalize*',
 	aliases:      [ 'n*' ],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
-		const result = await normalize(config, shell, handleString(remainingLine));
+	fn:           async(output, shell, remainingLine, _, config) => {
+		const result = await normalize(shell, handleString(remainingLine), config);
 		const mermaid = normalizedAstToMermaidUrl(result.normalize.ast);
 		output.stdout(mermaid);
 		try {

--- a/src/cli/repl/commands/repl-parse.ts
+++ b/src/cli/repl/commands/repl-parse.ts
@@ -162,10 +162,10 @@ export const parseCommand: ReplCommand = {
 	usageExample: ':parse',
 	aliases:      [ 'p' ],
 	script:       false,
-	fn:           async(output, parser, remainingLine) => {
+	fn:           async(config, output, parser, remainingLine) => {
 		const result = await createParsePipeline(parser, {
 			request: requestFromInput(removeRQuotes(remainingLine.trim()))
-		}).allRemainingSteps();
+		}, config).allRemainingSteps();
 
 		if(parser.name === 'r-shell') {
 			const object = convertPreparedParsedData(prepareParsedData(result.parse.parsed as unknown as string));

--- a/src/cli/repl/commands/repl-parse.ts
+++ b/src/cli/repl/commands/repl-parse.ts
@@ -2,11 +2,8 @@ import type { ReplCommand } from './repl-main';
 import type { OutputFormatter } from '../../../util/text/ansi';
 import { FontStyles } from '../../../util/text/ansi';
 import type { JsonEntry } from '../../../r-bridge/lang-4.x/ast/parser/json/format';
-import { convertPreparedParsedData , prepareParsedData } from '../../../r-bridge/lang-4.x/ast/parser/json/format';
-import {
-	extractLocation,
-	getTokenType,
-} from '../../../r-bridge/lang-4.x/ast/parser/main/normalize-meta';
+import { convertPreparedParsedData, prepareParsedData } from '../../../r-bridge/lang-4.x/ast/parser/json/format';
+import { extractLocation, getTokenType, } from '../../../r-bridge/lang-4.x/ast/parser/main/normalize-meta';
 import { createParsePipeline } from '../../../core/steps/pipeline/default-pipelines';
 import { fileProtocol, removeRQuotes, requestFromInput } from '../../../r-bridge/retriever';
 import type Parser from 'web-tree-sitter';
@@ -162,7 +159,7 @@ export const parseCommand: ReplCommand = {
 	usageExample: ':parse',
 	aliases:      [ 'p' ],
 	script:       false,
-	fn:           async(config, output, parser, remainingLine) => {
+	fn:           async(output, parser, remainingLine, _, config) => {
 		const result = await createParsePipeline(parser, {
 			request: requestFromInput(removeRQuotes(remainingLine.trim()))
 		}, config).allRemainingSteps();

--- a/src/cli/repl/commands/repl-query.ts
+++ b/src/cli/repl/commands/repl-query.ts
@@ -6,7 +6,7 @@ import { splitAtEscapeSensitive } from '../../../util/text/args';
 import { ansiFormatter, italic } from '../../../util/text/ansi';
 import { describeSchema } from '../../../util/schema';
 import type { Query, QueryResults, SupportedQueryTypes } from '../../../queries/query';
-import { AnyQuerySchema, QueriesSchema , executeQueries } from '../../../queries/query';
+import { AnyQuerySchema, executeQueries, QueriesSchema } from '../../../queries/query';
 import type { PipelineOutput } from '../../../core/steps/pipeline/pipeline';
 import { jsonReplacer } from '../../../util/json';
 import { asciiSummaryOfQueryResult } from '../../../queries/query-print';
@@ -32,7 +32,7 @@ function printHelp(output: ReplOutput) {
 	output.stdout(`With this, ${italic(':query @config', output.formatter)} prints the result of the config query.`);
 }
 
-async function processQueryArgs(config: FlowrConfigOptions, line: string, parser: KnownParser, output: ReplOutput): Promise<undefined | { query: QueryResults<SupportedQueryTypes>, processed: PipelineOutput<typeof DEFAULT_DATAFLOW_PIPELINE> }> {
+async function processQueryArgs(line: string, parser: KnownParser, output: ReplOutput, config: FlowrConfigOptions): Promise<undefined | { query: QueryResults<SupportedQueryTypes>, processed: PipelineOutput<typeof DEFAULT_DATAFLOW_PIPELINE> }> {
 	const args = splitAtEscapeSensitive(line);
 	const query = args.shift();
 
@@ -78,9 +78,9 @@ export const queryCommand: ReplCommand = {
 	usageExample: ':query "<query>" <code>',
 	aliases:      [],
 	script:       false,
-	fn:           async(config, output, parser, remainingLine) => {
+	fn:           async(output, parser, remainingLine, _, config) => {
 		const totalStart = Date.now();
-		const results = await processQueryArgs(config, remainingLine, parser, output);
+		const results = await processQueryArgs(remainingLine, parser, output, config);
 		const totalEnd = Date.now();
 		if(results) {
 			output.stdout(asciiSummaryOfQueryResult(ansiFormatter, totalEnd - totalStart, results.query, results.processed));
@@ -93,8 +93,8 @@ export const queryStarCommand: ReplCommand = {
 	usageExample: ':query* <query> <code>',
 	aliases:      [ ],
 	script:       false,
-	fn:           async(config, output, shell, remainingLine) => {
-		const results = await processQueryArgs(config, remainingLine, shell, output);
+	fn:           async(output, shell, remainingLine, _, config) => {
+		const results = await processQueryArgs(remainingLine, shell, output, config);
 		if(results) {
 			output.stdout(JSON.stringify(results.query, jsonReplacer));
 		}

--- a/src/cli/repl/commands/repl-query.ts
+++ b/src/cli/repl/commands/repl-query.ts
@@ -68,7 +68,7 @@ async function processQueryArgs(config: FlowrConfigOptions, line: string, parser
 
 	const processed = await getDataflow(config, parser, args.join(' '));
 	return {
-		query: executeQueries({ dataflow: processed.dataflow, ast: processed.normalize }, parsedQuery),
+		query: executeQueries({ dataflow: processed.dataflow, ast: processed.normalize, config: config }, parsedQuery),
 		processed
 	};
 }

--- a/src/cli/repl/commands/repl-version.ts
+++ b/src/cli/repl/commands/repl-version.ts
@@ -40,5 +40,5 @@ export const versionCommand: ReplCommand = {
 	aliases:      [],
 	usageExample: ':version',
 	script:       false,
-	fn:           (_config, output, parser) => printVersionInformation(output, parser)
+	fn:           (output, parser) => printVersionInformation(output, parser)
 };

--- a/src/cli/repl/commands/repl-version.ts
+++ b/src/cli/repl/commands/repl-version.ts
@@ -40,5 +40,5 @@ export const versionCommand: ReplCommand = {
 	aliases:      [],
 	usageExample: ':version',
 	script:       false,
-	fn:           (output, parser) => printVersionInformation(output, parser)
+	fn:           (_config, output, parser) => printVersionInformation(output, parser)
 };

--- a/src/cli/repl/core.ts
+++ b/src/cli/repl/core.ts
@@ -20,7 +20,7 @@ import { RShell, RShellReviveOptions } from '../../r-bridge/shell';
 import type { MergeableRecord } from '../../util/objects';
 import type { KnownParser } from '../../r-bridge/parser';
 import { log, LogLevel } from '../../util/log';
-import type { FlowrConfigOptions } from '../../config';
+import {FlowrConfigOptions, getEngineConfig} from '../../config';
 
 let _replCompleterKeywords: string[] | undefined = undefined;
 function replCompleterKeywords() {
@@ -155,7 +155,7 @@ export interface FlowrReplOptions extends MergeableRecord {
 export async function repl(
 	config : FlowrConfigOptions,
 	{
-		parser = new RShell({ revive: RShellReviveOptions.Always }),
+		parser = new RShell(getEngineConfig(config, 'r-shell'), { revive: RShellReviveOptions.Always }),
 		rl = readline.createInterface(makeDefaultReplReadline()),
 		output = standardReplOutput,
 		historyFile = defaultHistoryFile,

--- a/src/cli/repl/server/connection.ts
+++ b/src/cli/repl/server/connection.ts
@@ -46,12 +46,14 @@ import type { KnownParser, ParseStepOutput } from '../../../r-bridge/parser';
 import type { PipelineExecutor } from '../../../core/pipeline-executor';
 import { compact } from './compact';
 import type { ControlFlowInformation } from '../../../control-flow/control-flow-graph';
+import type { FlowrConfigOptions } from '../../../config';
 
 /**
  * Each connection handles a single client, answering to its requests.
  * There is no need to construct this class manually, {@link FlowRServer} will do it for you.
  */
 export class FlowRServerConnection {
+	private readonly config:              FlowrConfigOptions;
 	private readonly socket:              Socket;
 	private readonly parser:              KnownParser;
 	private readonly name:                string;
@@ -65,7 +67,8 @@ export class FlowRServerConnection {
 	}>();
 
 	// we do not have to ensure synchronized shell-access as we are always running synchronized
-	constructor(socket: Socket, name: string, parser: KnownParser, allowRSessionAccess: boolean) {
+	constructor(config: FlowrConfigOptions, socket: Socket, name: string, parser: KnownParser, allowRSessionAccess: boolean) {
+		this.config = config;
 		this.socket = socket;
 		this.parser = parser;
 		this.name = name;
@@ -219,7 +222,7 @@ export class FlowRServerConnection {
 		const slicer = createSlicePipeline(this.parser, {
 			request,
 			criterion: [] // currently unknown
-		});
+		}, this.config);
 		if(message.filetoken) {
 			this.logger.info(`Storing file token ${message.filetoken}`);
 			this.fileMap.set(message.filetoken, {

--- a/src/cli/repl/server/connection.ts
+++ b/src/cli/repl/server/connection.ts
@@ -371,7 +371,7 @@ export class FlowRServerConnection {
 		const { dataflow: dfg, normalize: ast } = fileInformation.pipeline.getResults(true);
 		guard(dfg !== undefined, `Dataflow graph must be present (request: ${request.filetoken})`);
 		guard(ast !== undefined, `AST must be present (request: ${request.filetoken})`);
-		const results = executeQueries({ dataflow: dfg, ast }, request.query);
+		const results = executeQueries({ dataflow: dfg, ast, config: this.config }, request.query);
 		sendMessage<QueryResponseMessage>(this.socket, {
 			type: 'response-query',
 			id:   request.id,

--- a/src/cli/repl/server/connection.ts
+++ b/src/cli/repl/server/connection.ts
@@ -1,7 +1,8 @@
 import { sendMessage } from './send';
 import { answerForValidationError, validateBaseMessageFormat, validateMessage } from './validate';
 import type {
-	FileAnalysisRequestMessage, FileAnalysisResponseMessageCompact,
+	FileAnalysisRequestMessage,
+	FileAnalysisResponseMessageCompact,
 	FileAnalysisResponseMessageNQuads
 } from './messages/message-analysis';
 import { requestAnalysisMessage } from './messages/message-analysis';
@@ -11,7 +12,11 @@ import type { FlowrErrorMessage } from './messages/message-error';
 import type { Socket } from './net';
 import { serverLog } from './server';
 import type { ILogObj, Logger } from 'tslog';
-import type { ExecuteEndMessage, ExecuteIntermediateResponseMessage, ExecuteRequestMessage } from './messages/message-repl';
+import type {
+	ExecuteEndMessage,
+	ExecuteIntermediateResponseMessage,
+	ExecuteRequestMessage
+} from './messages/message-repl';
 import { requestExecuteReplExpressionMessage } from './messages/message-repl';
 import { replProcessAnswer } from '../core';
 import { LogLevel } from '../../../util/log';
@@ -53,12 +58,12 @@ import type { FlowrConfigOptions } from '../../../config';
  * There is no need to construct this class manually, {@link FlowRServer} will do it for you.
  */
 export class FlowRServerConnection {
-	private readonly config:              FlowrConfigOptions;
 	private readonly socket:              Socket;
 	private readonly parser:              KnownParser;
 	private readonly name:                string;
 	private readonly logger:              Logger<ILogObj>;
 	private readonly allowRSessionAccess: boolean;
+	private readonly config:              FlowrConfigOptions;
 
 	// maps token to information
 	private readonly fileMap = new Map<string, {
@@ -67,7 +72,7 @@ export class FlowRServerConnection {
 	}>();
 
 	// we do not have to ensure synchronized shell-access as we are always running synchronized
-	constructor(config: FlowrConfigOptions, socket: Socket, name: string, parser: KnownParser, allowRSessionAccess: boolean) {
+	constructor(socket: Socket, name: string, parser: KnownParser, allowRSessionAccess: boolean, config: FlowrConfigOptions) {
 		this.config = config;
 		this.socket = socket;
 		this.parser = parser;

--- a/src/cli/repl/server/connection.ts
+++ b/src/cli/repl/server/connection.ts
@@ -299,7 +299,7 @@ export class FlowRServerConnection {
 			});
 		};
 
-		void replProcessAnswer({
+		void replProcessAnswer(this.config, {
 			formatter: request.ansi ? ansiFormatter : voidFormatter,
 			stdout:    msg => out('stdout', msg),
 			stderr:    msg => out('stderr', msg)

--- a/src/cli/repl/server/server.ts
+++ b/src/cli/repl/server/server.ts
@@ -19,24 +19,24 @@ export const serverLog = new FlowrLogger({ name: 'server' });
  * thereon be handled by a {@link FlowRServerConnection}.
  */
 export class FlowRServer {
-	private readonly config:			           FlowrConfigOptions;
 	private readonly server:              Server;
 	private readonly engines:             KnownEngines;
 	private readonly defaultEngine:       keyof KnownEngines;
 	private versionInformation:           VersionInformation | undefined;
 	private readonly allowRSessionAccess: boolean;
+	private readonly config:			           FlowrConfigOptions;
 
 	/** maps names to the respective connection */
 	private readonly connections = new Map<string, FlowRServerConnection>();
 	private nameCounter = 0;
 
-	constructor(config: FlowrConfigOptions, engines: KnownEngines, defaultEngine: keyof KnownEngines, allowRSessionAccess: boolean, server: Server = new NetServer()) {
-		this.config = config;
+	constructor(engines: KnownEngines, defaultEngine: keyof KnownEngines, allowRSessionAccess: boolean, config: FlowrConfigOptions, server: Server = new NetServer()) {
 		this.server = server;
 		this.server.onConnect(c => this.onConnect(c));
 		this.engines = engines;
 		this.defaultEngine = defaultEngine;
 		this.allowRSessionAccess = allowRSessionAccess;
+		this.config = config;
 	}
 
 	public async start(port: number) {
@@ -53,7 +53,7 @@ export class FlowRServer {
 		const name = `client-${this.nameCounter++}`;
 		serverLog.info(`Client connected: ${getUnnamedSocketName(c)} as "${name}"`);
 
-		this.connections.set(name, new FlowRServerConnection(this.config, c, name, this.engines[this.defaultEngine] as KnownParser, this.allowRSessionAccess));
+		this.connections.set(name, new FlowRServerConnection(c, name, this.engines[this.defaultEngine] as KnownParser, this.allowRSessionAccess, this.config));
 		helloClient(c, name, this.versionInformation);
 		c.on('close', () => {
 			this.connections.delete(name);

--- a/src/cli/script-core/statistics-core.ts
+++ b/src/cli/script-core/statistics-core.ts
@@ -58,7 +58,7 @@ async function collectFileArguments(options: StatsCliOptions, verboseAdd: readon
 	return files;
 }
 
-export async function flowrScriptGetStats(config: FlowrConfigOptions, options: StatsCliOptions) {
+export async function flowrScriptGetStats(options: StatsCliOptions, config: FlowrConfigOptions) {
 	if(options.input.length === 0) {
 		console.error('No input files given. Nothing to do. See \'--help\' if this is an error.');
 		process.exit(0);
@@ -105,7 +105,7 @@ export async function flowrScriptGetStats(config: FlowrConfigOptions, options: S
 	} else {
 		console.log('Run Sequentially as parallel <= 0...');
 		for(const arg of args) {
-			await getStatsForSingleFile(config, commandLineArgs(scripts['stats-helper'].options, { argv: arg }) as StatsHelperCliOptions);
+			await getStatsForSingleFile(commandLineArgs(scripts['stats-helper'].options, { argv: arg }) as StatsHelperCliOptions, config);
 		}
 	}
 }

--- a/src/cli/script-core/statistics-core.ts
+++ b/src/cli/script-core/statistics-core.ts
@@ -13,6 +13,7 @@ import commandLineArgs from 'command-line-args';
 import { scripts } from '../common/scripts-info';
 import type { StatsHelperCliOptions } from '../statistics-helper-app';
 import { setFormatter, voidFormatter } from '../../util/text/ansi';
+import type { FlowrConfigOptions } from '../../config';
 
 const testRegex = /[^/]*\/test/i;
 const exampleRegex = /[^/]*\/example/i;
@@ -57,7 +58,7 @@ async function collectFileArguments(options: StatsCliOptions, verboseAdd: readon
 	return files;
 }
 
-export async function flowrScriptGetStats(options: StatsCliOptions) {
+export async function flowrScriptGetStats(config: FlowrConfigOptions, options: StatsCliOptions) {
 	if(options.input.length === 0) {
 		console.error('No input files given. Nothing to do. See \'--help\' if this is an error.');
 		process.exit(0);
@@ -104,7 +105,7 @@ export async function flowrScriptGetStats(options: StatsCliOptions) {
 	} else {
 		console.log('Run Sequentially as parallel <= 0...');
 		for(const arg of args) {
-			await getStatsForSingleFile(commandLineArgs(scripts['stats-helper'].options, { argv: arg }) as StatsHelperCliOptions);
+			await getStatsForSingleFile(config, commandLineArgs(scripts['stats-helper'].options, { argv: arg }) as StatsHelperCliOptions);
 		}
 	}
 }

--- a/src/cli/script-core/statistics-helper-core.ts
+++ b/src/cli/script-core/statistics-helper-core.ts
@@ -37,7 +37,7 @@ function compressFolder(folder: string, target: string) {
 }
 
 
-export async function getStatsForSingleFile(config: FlowrConfigOptions, options: StatsHelperCliOptions) {
+export async function getStatsForSingleFile(options: StatsHelperCliOptions, config: FlowrConfigOptions) {
 	if(options['no-ansi']) {
 		log.info('disabling ansi colors');
 		setFormatter(voidFormatter);

--- a/src/cli/script-core/statistics-helper-core.ts
+++ b/src/cli/script-core/statistics-helper-core.ts
@@ -16,6 +16,8 @@ import { date2string } from '../../util/text/time';
 import type { StatsHelperCliOptions } from '../statistics-helper-app';
 import { create } from 'tar';
 import { setFormatter, voidFormatter } from '../../util/text/ansi';
+import type { FlowrConfigOptions } from '../../config';
+import { getEngineConfig } from '../../config';
 
 function compressFolder(folder: string, target: string) {
 	 
@@ -35,7 +37,7 @@ function compressFolder(folder: string, target: string) {
 }
 
 
-export async function getStatsForSingleFile(options: StatsHelperCliOptions) {
+export async function getStatsForSingleFile(config: FlowrConfigOptions, options: StatsHelperCliOptions) {
 	if(options['no-ansi']) {
 		log.info('disabling ansi colors');
 		setFormatter(voidFormatter);
@@ -53,12 +55,13 @@ export async function getStatsForSingleFile(options: StatsHelperCliOptions) {
 	// assume correct
 	const processedFeatures = new Set<FeatureKey>(options.features as FeatureKey[]);
 
-	const shell = new RShell();
+	const shell = new RShell(getEngineConfig(config, 'r-shell'));
 
 	initFileProvider(options['output-dir']);
 
 	await shell.obtainTmpDir();
 	const stats = await extractUsageStatistics(shell,
+		config,
 		() => { /* do nothing */ },
 		processedFeatures,
 		staticRequests({ request: 'file', content: options.input }),

--- a/src/cli/slicer-app.ts
+++ b/src/cli/slicer-app.ts
@@ -45,7 +45,7 @@ async function getSlice() {
 	guard(options.input !== undefined, 'input must be given');
 	guard(options.criterion !== undefined, 'a slicing criterion must be given');
 
-	const config = getConfig(undefined);
+	const config = getConfig();
 
 	await slicer.init(
 		options['input-is-text']

--- a/src/cli/statistics-app.ts
+++ b/src/cli/statistics-app.ts
@@ -25,4 +25,4 @@ const scriptOptions = processCommandLineArgs<StatsCliOptions>('stats', [],{
 	]
 });
 
-void flowrScriptGetStats(getConfig(undefined), scriptOptions);
+void flowrScriptGetStats(scriptOptions, getConfig());

--- a/src/cli/statistics-app.ts
+++ b/src/cli/statistics-app.ts
@@ -1,5 +1,6 @@
 import { processCommandLineArgs } from './common/script';
 import { flowrScriptGetStats } from './script-core/statistics-core';
+import { getConfig } from '../config';
 
 export interface StatsCliOptions {
 	readonly verbose:      boolean
@@ -24,4 +25,4 @@ const scriptOptions = processCommandLineArgs<StatsCliOptions>('stats', [],{
 	]
 });
 
-void flowrScriptGetStats(scriptOptions);
+void flowrScriptGetStats(getConfig(undefined), scriptOptions);

--- a/src/cli/statistics-helper-app.ts
+++ b/src/cli/statistics-helper-app.ts
@@ -1,5 +1,6 @@
 import { processCommandLineArgs } from './common/script';
 import { getStatsForSingleFile } from './script-core/statistics-helper-core';
+import { getConfig } from '../config';
 
 // apps should never depend on other apps when forking (otherwise, they are "run" whenever their root-files are loaded!)
 
@@ -23,4 +24,4 @@ const scriptOptions = processCommandLineArgs<StatsHelperCliOptions>('stats-helpe
 	]
 });
 
-void getStatsForSingleFile(scriptOptions);
+void getStatsForSingleFile(getConfig(undefined), scriptOptions);

--- a/src/cli/statistics-helper-app.ts
+++ b/src/cli/statistics-helper-app.ts
@@ -24,4 +24,4 @@ const scriptOptions = processCommandLineArgs<StatsHelperCliOptions>('stats-helpe
 	]
 });
 
-void getStatsForSingleFile(getConfig(undefined), scriptOptions);
+void getStatsForSingleFile(scriptOptions, getConfig());

--- a/src/config.ts
+++ b/src/config.ts
@@ -280,13 +280,11 @@ export function parseConfig(jsonString: string): FlowrConfigOptions | undefined 
 	}
 }
 
-// TODO remove this function?
 export function amendConfig(config: FlowrConfigOptions, amendment: DeepPartial<FlowrConfigOptions>) {
 	return deepMergeObject(config, amendment) as FlowrConfigOptions;
 }
 
-// TODO Simplify parameters?
-export function getConfig(configFile: string | undefined, configWorkingDirectory = process.cwd()): FlowrConfigOptions {
+export function getConfig(configFile?: string, configWorkingDirectory = process.cwd()): FlowrConfigOptions {
 	try {
 		return loadConfigFromFile(configFile, configWorkingDirectory);
 	} catch(e) {

--- a/src/core/pipeline-executor.ts
+++ b/src/core/pipeline-executor.ts
@@ -4,7 +4,8 @@ import { PipelineStepStage } from './steps/pipeline-step';
 import type {
 	Pipeline,
 	PipelineInput,
-	PipelineOutput, PipelinePerRequestInput,
+	PipelineOutput,
+	PipelinePerRequestInput,
 	PipelineStepNames,
 	PipelineStepOutputWithName
 } from './steps/pipeline/pipeline';
@@ -112,7 +113,7 @@ export class PipelineExecutor<P extends Pipeline> {
 	 *
 	 * @param pipeline - The {@link Pipeline} to execute, probably created with {@link createPipeline}.
 	 * @param input    - External {@link PipelineInput|configuration and input} required to execute the given pipeline.
-	 * @param config   - The FlowrConfig containing the built-in definitions
+	 * @param config   - The flowr config containing the built-in definitions
 	 */
 	constructor(pipeline: P, input: PipelineInput<P>, config: FlowrConfigOptions) {
 		this.pipeline = pipeline;

--- a/src/core/pipeline-executor.ts
+++ b/src/core/pipeline-executor.ts
@@ -8,7 +8,7 @@ import type {
 	PipelineStepNames,
 	PipelineStepOutputWithName
 } from './steps/pipeline/pipeline';
-import { getConfig } from '../config';
+import type { FlowrConfigOptions } from '../config';
 import { BuiltInMemory, EmptyBuiltInMemory } from '../dataflow/environments/built-in';
 import { registerBuiltInDefinitions } from '../dataflow/environments/built-in-config';
 
@@ -112,12 +112,12 @@ export class PipelineExecutor<P extends Pipeline> {
 	 *
 	 * @param pipeline - The {@link Pipeline} to execute, probably created with {@link createPipeline}.
 	 * @param input    - External {@link PipelineInput|configuration and input} required to execute the given pipeline.
+	 * @param config   - The FlowrConfig containing the built-in definitions
 	 */
-	constructor(pipeline: P, input: PipelineInput<P>) {
+	constructor(pipeline: P, input: PipelineInput<P>, config: FlowrConfigOptions) {
 		this.pipeline = pipeline;
 		this.length = pipeline.order.length;
 		this.input = input;
-		const config = getConfig();
 		const builtIns = config.semantics.environment.overwriteBuiltIns;
 		if(!builtIns.loadDefaults) {
 			BuiltInMemory.clear();

--- a/src/core/steps/all/core/11-normalize-tree-sitter.ts
+++ b/src/core/steps/all/core/11-normalize-tree-sitter.ts
@@ -15,7 +15,7 @@ import type { ParseStepOutputTS } from './01-parse-tree-sitter';
 import type { FlowrConfigOptions } from '../../../../config';
 
 function processor(results: { 'parse'?: ParseStepOutputTS }, input: Partial<NormalizeRequiredInput>, config: FlowrConfigOptions) {
-	return normalizeTreeSitter(config, results['parse'] as ParseStepOutputTS, input.getId, getCurrentRequestFile(input.request));
+	return normalizeTreeSitter(results['parse'] as ParseStepOutputTS, input.getId, config, getCurrentRequestFile(input.request));
 }
 
 export const NORMALIZE_TREE_SITTER = {

--- a/src/core/steps/all/core/11-normalize-tree-sitter.ts
+++ b/src/core/steps/all/core/11-normalize-tree-sitter.ts
@@ -12,9 +12,10 @@ import { normalizeTreeSitter } from '../../../../r-bridge/lang-4.x/ast/parser/js
 import type { NormalizeRequiredInput } from './10-normalize';
 import { getCurrentRequestFile } from './10-normalize';
 import type { ParseStepOutputTS } from './01-parse-tree-sitter';
+import type { FlowrConfigOptions } from '../../../../config';
 
-function processor(results: { 'parse'?: ParseStepOutputTS }, input: Partial<NormalizeRequiredInput>) {
-	return normalizeTreeSitter(results['parse'] as ParseStepOutputTS, input.getId, getCurrentRequestFile(input.request));
+function processor(results: { 'parse'?: ParseStepOutputTS }, input: Partial<NormalizeRequiredInput>, config: FlowrConfigOptions) {
+	return normalizeTreeSitter(config, results['parse'] as ParseStepOutputTS, input.getId, getCurrentRequestFile(input.request));
 }
 
 export const NORMALIZE_TREE_SITTER = {

--- a/src/core/steps/all/core/20-dataflow.ts
+++ b/src/core/steps/all/core/20-dataflow.ts
@@ -12,6 +12,7 @@ import type { NormalizedAst } from '../../../../r-bridge/lang-4.x/ast/model/proc
 import type { RParseRequests } from '../../../../r-bridge/retriever';
 import { produceDataFlowGraph } from '../../../../dataflow/extractor';
 import type { KnownParserType, Parser } from '../../../../r-bridge/parser';
+import type { FlowrConfigOptions } from '../../../../config';
 
 const staticDataflowCommon = {
 	name:        'dataflow',
@@ -27,8 +28,8 @@ const staticDataflowCommon = {
 	dependencies: [ 'normalize' ],
 } as const;
 
-function processor(results: { normalize?: NormalizedAst }, input: { request?: RParseRequests, parser?: Parser<KnownParserType> }) {
-	return produceDataFlowGraph(input.parser as Parser<KnownParserType>, input.request as RParseRequests, results.normalize as NormalizedAst);
+function processor(results: { normalize?: NormalizedAst }, input: { request?: RParseRequests, parser?: Parser<KnownParserType> }, config: FlowrConfigOptions) {
+	return produceDataFlowGraph(input.parser as Parser<KnownParserType>, input.request as RParseRequests, results.normalize as NormalizedAst, config);
 }
 
 export const STATIC_DATAFLOW = {

--- a/src/core/steps/pipeline-step.ts
+++ b/src/core/steps/pipeline-step.ts
@@ -6,6 +6,7 @@
 
 import type { MergeableRecord } from '../../util/objects';
 import type { InternalStepPrinter, IPipelineStepPrinter, StepOutputFormat } from '../print/print';
+import type { FlowrConfigOptions } from '../../config';
 
 /**
  * This represents the format of a step processor which retrieves two things:
@@ -19,7 +20,7 @@ import type { InternalStepPrinter, IPipelineStepPrinter, StepOutputFormat } from
  * already covered transitively.
  */
 export type StepProcessingFunction =
-	(results: Record<string, unknown>, input: Record<string, unknown>) => unknown
+	(results: Record<string, unknown>, input: Record<string, unknown>, config: FlowrConfigOptions) => unknown
 /**
  * This represents the required execution frequency of a step.
  */

--- a/src/core/steps/pipeline/default-pipelines.ts
+++ b/src/core/steps/pipeline/default-pipelines.ts
@@ -14,6 +14,7 @@ import type { KnownParser, Parser } from '../../../r-bridge/parser';
 import { PipelineExecutor } from '../../pipeline-executor';
 import type { RShell } from '../../../r-bridge/shell';
 import type { TreeSitterExecutor } from '../../../r-bridge/lang-4.x/tree-sitter/tree-sitter-executor';
+import type { FlowrConfigOptions } from '../../../config';
 
 export const DEFAULT_SLICING_PIPELINE = createPipeline(PARSE_WITH_R_SHELL_STEP, NORMALIZE, STATIC_DATAFLOW, STATIC_SLICE, NAIVE_RECONSTRUCT);
 export const DEFAULT_SLICE_AND_RECONSTRUCT_PIPELINE = DEFAULT_SLICING_PIPELINE;
@@ -38,71 +39,71 @@ export const DEFAULT_PARSE_PIPELINE = createPipeline(PARSE_WITH_R_SHELL_STEP);
 export const TREE_SITTER_PARSE_PIPELINE = createPipeline(PARSE_WITH_TREE_SITTER_STEP);
 
 
-export function createParsePipeline(parser: TreeSitterExecutor, inputs: Omit<PipelineInput<typeof DEFAULT_PARSE_PIPELINE>, 'parser'>): PipelineExecutor<typeof TREE_SITTER_PARSE_PIPELINE>
-export function createParsePipeline(parser: RShell, inputs: Omit<PipelineInput<typeof DEFAULT_PARSE_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_PARSE_PIPELINE>
-export function createParsePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_PARSE_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_PARSE_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_PARSE_PIPELINE>
+export function createParsePipeline(parser: TreeSitterExecutor, inputs: Omit<PipelineInput<typeof DEFAULT_PARSE_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof TREE_SITTER_PARSE_PIPELINE>
+export function createParsePipeline(parser: RShell, inputs: Omit<PipelineInput<typeof DEFAULT_PARSE_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_PARSE_PIPELINE>
+export function createParsePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_PARSE_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_PARSE_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_PARSE_PIPELINE>
 /**
  * Returns either a {@link DEFAULT_PARSE_PIPELINE} or a {@link TREE_SITTER_PARSE_PIPELINE} depending on the parser used.
  *
  * @see {@link createNormalizePipeline}, {@link createDataflowPipeline}, {@link createSlicePipeline}
  */
-export function createParsePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_PARSE_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_PARSE_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_PARSE_PIPELINE> {
+export function createParsePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_PARSE_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_PARSE_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_PARSE_PIPELINE> {
 	const base = parser.name === 'tree-sitter' ? TREE_SITTER_PARSE_PIPELINE : DEFAULT_PARSE_PIPELINE;
 	return new PipelineExecutor(base as typeof DEFAULT_PARSE_PIPELINE, {
 		parser: parser as Parser<string>,
 		...inputs
-	});
+	}, config);
 }
 
 
-export function createSlicePipeline(parser: TreeSitterExecutor, inputs: Omit<PipelineInput<typeof DEFAULT_SLICING_PIPELINE>, 'parser'>): PipelineExecutor<typeof TREE_SITTER_SLICING_PIPELINE>
-export function createSlicePipeline(parser: RShell, inputs: Omit<PipelineInput<typeof DEFAULT_SLICING_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_SLICING_PIPELINE>
-export function createSlicePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_SLICING_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_SLICING_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_SLICING_PIPELINE>
+export function createSlicePipeline(parser: TreeSitterExecutor, inputs: Omit<PipelineInput<typeof DEFAULT_SLICING_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof TREE_SITTER_SLICING_PIPELINE>
+export function createSlicePipeline(parser: RShell, inputs: Omit<PipelineInput<typeof DEFAULT_SLICING_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_SLICING_PIPELINE>
+export function createSlicePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_SLICING_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_SLICING_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_SLICING_PIPELINE>
 /**
  * Returns either a {@link DEFAULT_SLICING_PIPELINE} or a {@link TREE_SITTER_SLICING_PIPELINE} depending on the parser used.
  *
  * @see {@link createParsePipeline}, {@link createNormalizePipeline}, {@link createDataflowPipeline}
  */
-export function createSlicePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_SLICING_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_SLICING_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_SLICING_PIPELINE> {
+export function createSlicePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_SLICING_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_SLICING_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_SLICING_PIPELINE> {
 	const base = parser.name === 'tree-sitter' ? TREE_SITTER_SLICING_PIPELINE : DEFAULT_SLICING_PIPELINE;
 	return new PipelineExecutor(base as typeof DEFAULT_SLICING_PIPELINE, {
 		parser: parser as Parser<string>,
 		...inputs
-	});
+	}, config);
 }
 
 
-export function createNormalizePipeline(parser: TreeSitterExecutor, inputs: Omit<PipelineInput<typeof DEFAULT_NORMALIZE_PIPELINE>, 'parser'>): PipelineExecutor<typeof TREE_SITTER_NORMALIZE_PIPELINE>
-export function createNormalizePipeline(parser: RShell, inputs: Omit<PipelineInput<typeof DEFAULT_NORMALIZE_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_NORMALIZE_PIPELINE>
-export function createNormalizePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_NORMALIZE_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_NORMALIZE_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_NORMALIZE_PIPELINE>
+export function createNormalizePipeline(parser: TreeSitterExecutor, inputs: Omit<PipelineInput<typeof DEFAULT_NORMALIZE_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof TREE_SITTER_NORMALIZE_PIPELINE>
+export function createNormalizePipeline(parser: RShell, inputs: Omit<PipelineInput<typeof DEFAULT_NORMALIZE_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_NORMALIZE_PIPELINE>
+export function createNormalizePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_NORMALIZE_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_NORMALIZE_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_NORMALIZE_PIPELINE>
 /**
  * Returns either a {@link DEFAULT_NORMALIZE_PIPELINE} or a {@link TREE_SITTER_NORMALIZE_PIPELINE} depending on the parser used.
  *
  * @see {@link createParsePipeline}, {@link createDataflowPipeline}, {@link createSlicePipeline}
  */
-export function createNormalizePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_NORMALIZE_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_NORMALIZE_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_NORMALIZE_PIPELINE> {
+export function createNormalizePipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_NORMALIZE_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_NORMALIZE_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_NORMALIZE_PIPELINE> {
 	const base = parser.name === 'tree-sitter' ? TREE_SITTER_NORMALIZE_PIPELINE : DEFAULT_NORMALIZE_PIPELINE;
 	return new PipelineExecutor(base as typeof DEFAULT_NORMALIZE_PIPELINE, {
 		parser: parser as Parser<string>,
 		...inputs
-	});
+	}, config);
 }
 
 
 
-export function createDataflowPipeline(parser: TreeSitterExecutor, inputs: Omit<PipelineInput<typeof DEFAULT_DATAFLOW_PIPELINE>, 'parser'>): PipelineExecutor<typeof TREE_SITTER_DATAFLOW_PIPELINE>
-export function createDataflowPipeline(parser: RShell, inputs: Omit<PipelineInput<typeof DEFAULT_DATAFLOW_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_DATAFLOW_PIPELINE>
-export function createDataflowPipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_DATAFLOW_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_DATAFLOW_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_DATAFLOW_PIPELINE>
+export function createDataflowPipeline(parser: TreeSitterExecutor, inputs: Omit<PipelineInput<typeof DEFAULT_DATAFLOW_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof TREE_SITTER_DATAFLOW_PIPELINE>
+export function createDataflowPipeline(parser: RShell, inputs: Omit<PipelineInput<typeof DEFAULT_DATAFLOW_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_DATAFLOW_PIPELINE>
+export function createDataflowPipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_DATAFLOW_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_DATAFLOW_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_DATAFLOW_PIPELINE>
 /**
  * Returns either a {@link DEFAULT_DATAFLOW_PIPELINE} or a {@link TREE_SITTER_DATAFLOW_PIPELINE} depending on the parser used.
  *
  * @see {@link createParsePipeline}, {@link createNormalizePipeline}, {@link createSlicePipeline}
  *
  */
-export function createDataflowPipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_DATAFLOW_PIPELINE>, 'parser'>): PipelineExecutor<typeof DEFAULT_DATAFLOW_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_DATAFLOW_PIPELINE> {
+export function createDataflowPipeline(parser: KnownParser, inputs: Omit<PipelineInput<typeof DEFAULT_DATAFLOW_PIPELINE>, 'parser'>, config: FlowrConfigOptions): PipelineExecutor<typeof DEFAULT_DATAFLOW_PIPELINE> | PipelineExecutor<typeof TREE_SITTER_DATAFLOW_PIPELINE> {
 	const base = parser.name === 'tree-sitter' ? TREE_SITTER_DATAFLOW_PIPELINE : DEFAULT_DATAFLOW_PIPELINE;
 	return new PipelineExecutor(base as typeof DEFAULT_DATAFLOW_PIPELINE, {
 		parser: parser as Parser<string>,
 		...inputs
-	});
+	}, config);
 }

--- a/src/dataflow/environments/define.ts
+++ b/src/dataflow/environments/define.ts
@@ -6,15 +6,15 @@ import { cloneEnvironmentInformation } from './clone';
 import type { IdentifierDefinition, InGraphIdentifierDefinition } from './identifier';
 import type { ContainerIndex, ContainerIndices } from '../graph/vertex';
 import { isParentContainerIndex, isSameIndex } from '../graph/vertex';
-import { getConfig } from '../../config';
+import type { FlowrConfigOptions } from '../../config';
 
-function defInEnv(newEnvironments: IEnvironment, name: string, definition: IdentifierDefinition) {
+function defInEnv(newEnvironments: IEnvironment, name: string, definition: IdentifierDefinition, config: FlowrConfigOptions) {
 	const existing = newEnvironments.memory.get(name);
 
 	// When there are defined indices, merge the definitions
 	const inGraphDefinition = definition as InGraphIdentifierDefinition;
 	if(
-		getConfig().solver.pointerTracking &&
+		config.solver.pointerTracking &&
 		existing !== undefined &&
 		inGraphDefinition.controlDependencies === undefined
 	) {
@@ -137,7 +137,7 @@ function overwriteContainerIndices(
  * Insert the given `definition` --- defined within the given scope --- into the passed along `environments` will take care of propagation.
  * Does not modify the passed along `environments` in-place! It returns the new reference.
  */
-export function define(definition: IdentifierDefinition, superAssign: boolean | undefined, environment: REnvironmentInformation): REnvironmentInformation {
+export function define(definition: IdentifierDefinition, superAssign: boolean | undefined, environment: REnvironmentInformation, config: FlowrConfigOptions): REnvironmentInformation {
 	const name = definition.name;
 	guard(name !== undefined, () => `Name must be defined, but isn't for ${JSON.stringify(definition)}`);
 	let newEnvironment;
@@ -161,7 +161,7 @@ export function define(definition: IdentifierDefinition, superAssign: boolean | 
 		}
 	} else {
 		newEnvironment = cloneEnvironmentInformation(environment, false);
-		defInEnv(newEnvironment.current, name, definition);
+		defInEnv(newEnvironment.current, name, definition, config);
 	}
 
 	return newEnvironment;

--- a/src/dataflow/environments/resolve-by-name.ts
+++ b/src/dataflow/environments/resolve-by-name.ts
@@ -296,9 +296,7 @@ export function trackAliasesInGraph(id: NodeId, graph: DataflowGraph, idMap?: As
  *
  * @see {@link resolveIdToValue} - for a more general approach which "evaluates" a node based on value resolve
  */
-export function resolveValueOfVariable(config: FlowrConfigOptions, identifier: Identifier | undefined, environment: REnvironmentInformation, idMap?: AstIdMap): unknown[] | undefined {
-	const resolve = config.solver.variables;
-
+export function resolveValueOfVariable(identifier: Identifier | undefined, environment: REnvironmentInformation, resolve: VariableResolve, idMap?: AstIdMap): unknown[] | undefined {
 	switch(resolve) {
 		case VariableResolve.Alias: return trackAliasInEnvironments(identifier, environment, idMap);
 		case VariableResolve.Builtin: return resolveToConstants(identifier, environment);
@@ -327,7 +325,7 @@ export interface ResolveInfo {
  * @param idMap       - The id map to resolve the node if given as an id
  * @param full        - Whether to track variables
  */
-export function resolveIdToValue(config: FlowrConfigOptions, id: NodeId | RNodeWithParent, { environment, graph, idMap, full } : ResolveInfo): unknown[] | undefined {
+export function resolveIdToValue(id: NodeId | RNodeWithParent, { environment, graph, idMap, full } : ResolveInfo, config: FlowrConfigOptions): unknown[] | undefined {
 	idMap ??= graph?.idMap;
 	const node = typeof id === 'object' ? id : idMap?.get(id);
 	if(node === undefined) {
@@ -336,7 +334,7 @@ export function resolveIdToValue(config: FlowrConfigOptions, id: NodeId | RNodeW
 	switch(node.type) {
 		case RType.Symbol:
 			if(environment) {
-				return full ? resolveValueOfVariable(config, node.lexeme, environment, idMap) : undefined;
+				return full ? resolveValueOfVariable(node.lexeme, environment, config.solver.variables, idMap) : undefined;
 			} else if(graph && config.solver.variables === VariableResolve.Alias) {
 				return full ? trackAliasesInGraph(node.info.id, graph, idMap) : undefined;
 			} else {

--- a/src/dataflow/extractor.ts
+++ b/src/dataflow/extractor.ts
@@ -27,6 +27,7 @@ import {
 	updateNestedFunctionCalls
 } from './internal/process/functions/call/built-in/built-in-function-definition';
 import type { ControlFlowGraph } from '../control-flow/control-flow-graph';
+import {FlowrConfigOptions} from "../config";
 
 /**
  * The best friend of {@link produceDataFlowGraph} and {@link processDataflowFor}.
@@ -94,7 +95,8 @@ function resolveLinkToSideEffects(ast: NormalizedAst, graph: DataflowGraph) {
 export function produceDataFlowGraph<OtherInfo>(
 	parser: Parser<KnownParserType>,
 	request: RParseRequests,
-	completeAst:     NormalizedAst<OtherInfo & ParentInformation>
+	completeAst:     NormalizedAst<OtherInfo & ParentInformation>,
+	config: FlowrConfigOptions
 ): DataflowInformation {
 	let firstRequest: RParseRequest;
 
@@ -113,6 +115,7 @@ export function produceDataFlowGraph<OtherInfo>(
 		currentRequest:      firstRequest,
 		controlDependencies: undefined,
 		referenceChain:      [firstRequest],
+		config
 	};
 	let df = processDataflowFor<OtherInfo>(completeAst.ast, dfData);
 	df.graph.sourced.unshift(firstRequest.request === 'file' ? firstRequest.content : '<inline>');

--- a/src/dataflow/extractor.ts
+++ b/src/dataflow/extractor.ts
@@ -23,11 +23,9 @@ import {
 	identifyLinkToLastCallRelation
 } from '../queries/catalog/call-context-query/identify-link-to-last-call-relation';
 import type { KnownParserType, Parser } from '../r-bridge/parser';
-import {
-	updateNestedFunctionCalls
-} from './internal/process/functions/call/built-in/built-in-function-definition';
+import { updateNestedFunctionCalls } from './internal/process/functions/call/built-in/built-in-function-definition';
 import type { ControlFlowGraph } from '../control-flow/control-flow-graph';
-import {FlowrConfigOptions} from "../config";
+import type { FlowrConfigOptions } from '../config';
 
 /**
  * The best friend of {@link produceDataFlowGraph} and {@link processDataflowFor}.

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-access.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-access.ts
@@ -23,7 +23,6 @@ import type {
 import { isParentContainerIndex } from '../../../../../graph/vertex';
 import type { RArgument } from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-argument';
 import { filterIndices, getAccessOperands, resolveSingleIndex } from '../../../../../../util/containers';
-import { getConfig } from '../../../../../../config';
 
 interface TableAssignmentProcessorMarker {
 	definitionRootNodes: NodeId[]
@@ -153,14 +152,14 @@ function processNumberBasedAccess<OtherInfo>(
 		data.environment.current.memory.set(':=', existing);
 	}
 	if(head.value && outInfo.definitionRootNodes.length > 0) {
-		markAsAssignment(fnCall.information,
+		markAsAssignment(data.config, fnCall.information,
 			{ type: ReferenceType.Variable, name: head.value.lexeme ?? '', nodeId: head.value.info.id, definedAt: rootId, controlDependencies: [] },
 			outInfo.definitionRootNodes,
 			rootId
 		);
 	}
 
-	if(getConfig().solver.pointerTracking) {
+	if(data.config.solver.pointerTracking) {
 		referenceAccessedIndices(args, data, fnCall, rootId, true);
 	}
 
@@ -213,7 +212,7 @@ function processStringBasedAccess<OtherInfo>(
 		origin:    'builtin:access' satisfies BuiltInMappingName
 	});
 
-	if(getConfig().solver.pointerTracking) {
+	if(data.config.solver.pointerTracking) {
 		referenceAccessedIndices(newArgs, data, fnCall, rootId, false);
 	}
 

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-access.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-access.ts
@@ -16,10 +16,7 @@ import type { BuiltInMappingName } from '../../../../../environments/built-in';
 import { builtInId } from '../../../../../environments/built-in';
 import { markAsAssignment } from './built-in-assignment';
 import { ReferenceType } from '../../../../../environments/identifier';
-import type {
-	ContainerIndicesCollection,
-	ContainerParentIndex
-} from '../../../../../graph/vertex';
+import type { ContainerIndicesCollection, ContainerParentIndex } from '../../../../../graph/vertex';
 import { isParentContainerIndex } from '../../../../../graph/vertex';
 import type { RArgument } from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-argument';
 import { filterIndices, getAccessOperands, resolveSingleIndex } from '../../../../../../util/containers';
@@ -152,10 +149,9 @@ function processNumberBasedAccess<OtherInfo>(
 		data.environment.current.memory.set(':=', existing);
 	}
 	if(head.value && outInfo.definitionRootNodes.length > 0) {
-		markAsAssignment(data.config, fnCall.information,
-			{ type: ReferenceType.Variable, name: head.value.lexeme ?? '', nodeId: head.value.info.id, definedAt: rootId, controlDependencies: [] },
+		markAsAssignment(fnCall.information, { type: ReferenceType.Variable, name: head.value.lexeme ?? '', nodeId: head.value.info.id, definedAt: rootId, controlDependencies: [] },
 			outInfo.definitionRootNodes,
-			rootId
+			rootId, data.config
 		);
 	}
 

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-apply.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-apply.ts
@@ -86,7 +86,7 @@ export function processApply<OtherInfo>(
 	} else if(val.type === RType.Symbol) {
 		functionId = val.info.id;
 		if(resolveValue) {
-			const resolved = resolveValueOfVariable(val.content, data.environment);
+			const resolved = resolveValueOfVariable(data.config, val.content, data.environment);
 			if(resolved?.length === 1 && typeof resolved[0] === 'string') {
 				functionName = resolved[0];
 			}

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-apply.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-apply.ts
@@ -86,7 +86,7 @@ export function processApply<OtherInfo>(
 	} else if(val.type === RType.Symbol) {
 		functionId = val.info.id;
 		if(resolveValue) {
-			const resolved = resolveValueOfVariable(data.config, val.content, data.environment);
+			const resolved = resolveValueOfVariable(val.content, data.environment, data.config.solver.variables);
 			if(resolved?.length === 1 && typeof resolved[0] === 'string') {
 				functionName = resolved[0];
 			}

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-assignment.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-assignment.ts
@@ -21,10 +21,9 @@ import { dataflowLogger } from '../../../../../logger';
 import type {
 	IdentifierReference,
 	InGraphIdentifierDefinition,
-	InGraphReferenceType } from '../../../../../environments/identifier';
-import {
-	ReferenceType
+	InGraphReferenceType
 } from '../../../../../environments/identifier';
+import { ReferenceType } from '../../../../../environments/identifier';
 import { overwriteEnvironment } from '../../../../../environments/overwrite';
 import type { RString } from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-string';
 import { removeRQuotes } from '../../../../../../r-bridge/retriever';
@@ -303,10 +302,10 @@ export interface AssignmentToSymbolParameters<OtherInfo> extends AssignmentConfi
  * @param nodeToDefine       - `x`
  * @param sourceIds          - `v`
  * @param rootIdOfAssignment - `<-`
- * @param assignmentConfig             - configuration for the assignment processing
+ * @param config             - The flowr config
+ * @param assignmentConfig   - configuration for the assignment processing
  */
 export function markAsAssignment(
-	config: FlowrConfigOptions,
 	information: {
 		environment: REnvironmentInformation,
 		graph:       DataflowGraph
@@ -314,6 +313,7 @@ export function markAsAssignment(
 	nodeToDefine: InGraphIdentifierDefinition,
 	sourceIds: readonly NodeId[],
 	rootIdOfAssignment: NodeId,
+	config: FlowrConfigOptions,
 	assignmentConfig?: AssignmentConfiguration  ,
 ) {
 	if(config.solver.pointerTracking) {
@@ -389,7 +389,7 @@ function processAssignmentToSymbol<OtherInfo>(config: AssignmentToSymbolParamete
 
 	// install assigned variables in environment
 	for(const write of writeNodes) {
-		markAsAssignment(data.config, information, write, [source.info.id], rootId, config);
+		markAsAssignment(information, write, [source.info.id], rootId, data.config, config);
 	}
 
 	information.graph.addEdge(rootId, targetArg.entryPoint, EdgeType.Returns);

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-eval.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-eval.ts
@@ -110,7 +110,7 @@ function resolveEvalToCode<OtherInfo>(evalArgument: RNode<OtherInfo & ParentInfo
 		if(arg.value?.type === RType.String) {
 			return [arg.value.content.str];
 		} else if(arg.value?.type === RType.Symbol) {
-			const resolve = resolveValueOfVariable(config, arg.value.content, env, idMap);
+			const resolve = resolveValueOfVariable(arg.value.content, env, config.solver.variables, idMap);
 			if(resolve?.every(r => typeof r === 'object' && r !== null && 'str' in r)) {
 				return resolve.map(r => r.str as string);
 			}
@@ -134,7 +134,7 @@ function getAsString(config: FlowrConfigOptions, val: RNode<ParentInformation> |
 	if(val.type === RType.String) {
 		return [val.content.str];
 	} else if(val.type === RType.Symbol) {
-		const resolved = resolveValueOfVariable(config, val.content, env, idMap);
+		const resolved = resolveValueOfVariable(val.content, env, config.solver.variables, idMap);
 		if(resolved?.every(r => typeof r === 'object' && r !== null && 'str' in r)) {
 			return resolved.map(r => r.str as string);
 		}

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-eval.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-eval.ts
@@ -1,7 +1,6 @@
 import { type DataflowProcessorInformation } from '../../../../../processor';
 import type { DataflowInformation } from '../../../../../info';
 import { initializeCleanDataflowInformation } from '../../../../../info';
-import { getConfig } from '../../../../../../config';
 import { processKnownFunctionCall } from '../known-call-handling';
 import { requestFromInput } from '../../../../../../r-bridge/retriever';
 import type { AstIdMap, ParentInformation } from '../../../../../../r-bridge/lang-4.x/ast/model/processing/decorate';
@@ -24,6 +23,7 @@ import { appendEnvironment } from '../../../../../environments/append';
 import type { RArgument } from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-argument';
 import { isUndefined } from '../../../../../../util/assert';
 import { cartesianProduct } from '../../../../../../util/collections/arrays';
+import type { FlowrConfigOptions } from '../../../../../../config';
 
 export function processEvalCall<OtherInfo>(
 	name: RSymbol<OtherInfo & ParentInformation>,
@@ -53,13 +53,13 @@ export function processEvalCall<OtherInfo>(
 		);
 	}
 
-	if(!getConfig().solver.evalStrings) {
+	if(!data.config.solver.evalStrings) {
 		expensiveTrace(dataflowLogger, () => `Skipping eval call ${JSON.stringify(evalArgument)} (disabled in config file)`);
 		information.graph.markIdForUnknownSideEffects(rootId);
 		return information;
 	}
 
-	const code: string[] | undefined = resolveEvalToCode(evalArgument.value as RNode<ParentInformation>, data.environment, data.completeAst.idMap);
+	const code: string[] | undefined = resolveEvalToCode(evalArgument.value as RNode<ParentInformation>, data.environment, data.completeAst.idMap, data.config);
 
 	if(code) {
 		const idGenerator = sourcedDeterministicCountingIdGenerator(name.lexeme + '::' + rootId, name.location);
@@ -96,7 +96,7 @@ export function processEvalCall<OtherInfo>(
 	return information;
 }
 
-function resolveEvalToCode<OtherInfo>(evalArgument: RNode<OtherInfo & ParentInformation>, env: REnvironmentInformation, idMap: AstIdMap): string[] | undefined {
+function resolveEvalToCode<OtherInfo>(evalArgument: RNode<OtherInfo & ParentInformation>, env: REnvironmentInformation, idMap: AstIdMap, config: FlowrConfigOptions): string[] | undefined {
 	const val = evalArgument;
 
 	if(
@@ -110,12 +110,12 @@ function resolveEvalToCode<OtherInfo>(evalArgument: RNode<OtherInfo & ParentInfo
 		if(arg.value?.type === RType.String) {
 			return [arg.value.content.str];
 		} else if(arg.value?.type === RType.Symbol) {
-			const resolve = resolveValueOfVariable(arg.value.content, env, idMap);
+			const resolve = resolveValueOfVariable(config, arg.value.content, env, idMap);
 			if(resolve?.every(r => typeof r === 'object' && r !== null && 'str' in r)) {
 				return resolve.map(r => r.str as string);
 			}
 		} else if(arg.value?.type === RType.FunctionCall && arg.value.named && ['paste', 'paste0'].includes(arg.value.functionName.content)) {
-			return handlePaste(arg.value.arguments, env, idMap, arg.value.functionName.content === 'paste' ? [' '] : ['']);
+			return handlePaste(config, arg.value.arguments, env, idMap, arg.value.functionName.content === 'paste' ? [' '] : ['']);
 		}
 		return undefined;
 	} else if(val.type === RType.Symbol) {
@@ -127,14 +127,14 @@ function resolveEvalToCode<OtherInfo>(evalArgument: RNode<OtherInfo & ParentInfo
 	}
 }
 
-function getAsString(val: RNode<ParentInformation> | undefined, env: REnvironmentInformation, idMap: AstIdMap): string[] | undefined {
+function getAsString(config: FlowrConfigOptions, val: RNode<ParentInformation> | undefined, env: REnvironmentInformation, idMap: AstIdMap): string[] | undefined {
 	if(!val) {
 		return undefined;
 	}
 	if(val.type === RType.String) {
 		return [val.content.str];
 	} else if(val.type === RType.Symbol) {
-		const resolved = resolveValueOfVariable(val.content, env, idMap);
+		const resolved = resolveValueOfVariable(config, val.content, env, idMap);
 		if(resolved?.every(r => typeof r === 'object' && r !== null && 'str' in r)) {
 			return resolved.map(r => r.str as string);
 		}
@@ -142,10 +142,10 @@ function getAsString(val: RNode<ParentInformation> | undefined, env: REnvironmen
 	return undefined;
 }
 
-function handlePaste(args: readonly RFunctionArgument<ParentInformation>[], env: REnvironmentInformation, idMap: AstIdMap, sepDefault: string[]): string[] | undefined {
+function handlePaste(config: FlowrConfigOptions, args: readonly RFunctionArgument<ParentInformation>[], env: REnvironmentInformation, idMap: AstIdMap, sepDefault: string[]): string[] | undefined {
 	const sepArg = args.find(v => v !== EmptyArgument && v.name?.content === 'sep');
 	if(sepArg) {
-		const res = sepArg !== EmptyArgument && sepArg.value ? getAsString(sepArg.value, env, idMap) : undefined;
+		const res = sepArg !== EmptyArgument && sepArg.value ? getAsString(config, sepArg.value, env, idMap) : undefined;
 		if(!res) {
 			// sep not resolvable clearly / unknown
 			return undefined;
@@ -155,7 +155,7 @@ function handlePaste(args: readonly RFunctionArgument<ParentInformation>[], env:
 
 	const allArgs = args
 		.filter(v => v !== EmptyArgument && v.name?.content !== 'sep' && v.value)
-		.map(v => getAsString((v as RArgument<ParentInformation>).value, env, idMap));
+		.map(v => getAsString(config, (v as RArgument<ParentInformation>).value, env, idMap));
 	if(allArgs.some(isUndefined)) {
 		return undefined;
 	}

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-for-loop.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-for-loop.ts
@@ -50,7 +50,7 @@ export function processForLoop<OtherInfo>(
 
 	const writtenVariable = [...variable.unknownReferences, ...variable.in];
 	for(const write of writtenVariable) {
-		headEnvironments = define({ ...write, definedAt: name.info.id, type: ReferenceType.Variable }, false, headEnvironments);
+		headEnvironments = define({ ...write, definedAt: name.info.id, type: ReferenceType.Variable }, false, headEnvironments, data.config);
 	}
 	data = { ...data, environment: headEnvironments };
 

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-if-then-else.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-if-then-else.ts
@@ -52,7 +52,7 @@ export function processIfThenElse<OtherInfo>(
 
 	// we should defer this to the abstract interpretation
 
-	const values = resolveValueOfVariable(data.config, condArg?.lexeme, data.environment, data.completeAst.idMap);
+	const values = resolveValueOfVariable(condArg?.lexeme, data.environment, data.config.solver.variables, data.completeAst.idMap);
 	const conditionIsAlwaysFalse = values?.every(d => d === false) ?? false;
 	const conditionIsAlwaysTrue  = values?.every(d => d === true) ?? false;
 

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-if-then-else.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-if-then-else.ts
@@ -52,7 +52,7 @@ export function processIfThenElse<OtherInfo>(
 
 	// we should defer this to the abstract interpretation
 
-	const values = resolveValueOfVariable(condArg?.lexeme, data.environment, data.completeAst.idMap);
+	const values = resolveValueOfVariable(data.config, condArg?.lexeme, data.environment, data.completeAst.idMap);
 	const conditionIsAlwaysFalse = values?.every(d => d === false) ?? false;
 	const conditionIsAlwaysTrue  = values?.every(d => d === true) ?? false;
 

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-list.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-list.ts
@@ -8,7 +8,7 @@ import type { ContainerIndices, ContainerIndex } from '../../../../../graph/vert
 import type { DataflowInformation } from '../../../../../info';
 import type { DataflowProcessorInformation } from '../../../../../processor';
 import { processKnownFunctionCall } from '../known-call-handling';
-import { getConfig, isOverPointerAnalysisThreshold } from '../../../../../../config';
+import { isOverPointerAnalysisThreshold } from '../../../../../../config';
 import { resolveIndicesByName } from '../../../../../../util/containers';
 
 /**
@@ -27,7 +27,7 @@ export function processList<OtherInfo>(
 ): DataflowInformation {
 	const fnCall = processKnownFunctionCall({ name, args, rootId, data, origin: 'builtin:list' });
 
-	if(!getConfig().solver.pointerTracking) {
+	if(!data.config.solver.pointerTracking) {
 		return fnCall.information;
 	}
 
@@ -82,7 +82,7 @@ export function processList<OtherInfo>(
 	}
 
 
-	if(isOverPointerAnalysisThreshold(listArgs.length)) {
+	if(isOverPointerAnalysisThreshold(data.config, listArgs.length)) {
 		return fnCall.information;
 	}
 

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-replacement.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-replacement.ts
@@ -24,7 +24,6 @@ import { getReferenceOfArgument } from '../../../../../graph/graph';
 import { EdgeType } from '../../../../../graph/edge';
 import { RType } from '../../../../../../r-bridge/lang-4.x/ast/model/type';
 import { constructNestedAccess, getAccessOperands } from '../../../../../../util/containers';
-import { getConfig } from '../../../../../../config';
 import type { RArgument } from '../../../../../../r-bridge/lang-4.x/ast/model/nodes/r-argument';
 import type { RNode } from '../../../../../../r-bridge/lang-4.x/ast/model/model';
 import { unpackArgument } from '../argument/unpack-argument';
@@ -52,7 +51,7 @@ export function processReplacementFunction<OtherInfo>(
 	expensiveTrace(dataflowLogger, () => `Replacement ${name.content} with ${JSON.stringify(args)}, processing`);
 
 	let indices: ContainerIndicesCollection = config.activeIndices;
-	if(getConfig().solver.pointerTracking) {
+	if(data.config.solver.pointerTracking) {
 		indices ??= constructAccessedIndices<OtherInfo>(name.content, args);
 	}
 
@@ -118,7 +117,7 @@ export function processReplacementFunction<OtherInfo>(
 
 
 	const fa = unpackArgument(args[0]);
-	if(!getConfig().solver.pointerTracking && fa) {
+	if(data.config.solver.pointerTracking && fa) {
 		res = {
 			...res,
 			in: [...res.in, { name: fa.lexeme, type: ReferenceType.Variable, nodeId: fa.info.id, controlDependencies: data.controlDependencies }]

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-source.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-source.ts
@@ -172,7 +172,7 @@ export function processSourceCall<OtherInfo>(
 	if(sourceFileArgument !== EmptyArgument && sourceFileArgument?.value?.type === RType.String) {
 		sourceFile = [removeRQuotes(sourceFileArgument.lexeme)];
 	} else if(sourceFileArgument !== EmptyArgument) {
-		sourceFile = resolveValueOfVariable(data.config, sourceFileArgument.value?.lexeme, data.environment, data.completeAst.idMap)?.map(x => {
+		sourceFile = resolveValueOfVariable(sourceFileArgument.value?.lexeme, data.environment, data.config.solver.variables, data.completeAst.idMap)?.map(x => {
 			if(typeof x === 'object' && x && 'str' in x) {
 				return x.str as string;
 			} else {
@@ -226,7 +226,7 @@ export function sourceRequest<OtherInfo>(rootId: NodeId, request: RParseRequest,
 		const file = request.request === 'file' ? request.content : undefined;
 		const parsed = (!data.parser.async ? data.parser : new RShellExecutor()).parse(request);
 		normalized = (typeof parsed !== 'string' ?
-			normalizeTreeSitter(data.config, { parsed }, getId, file) : normalize({ parsed }, getId, file)) as NormalizedAst<OtherInfo & ParentInformation>;
+			normalizeTreeSitter({ parsed }, getId, data.config, file) : normalize({ parsed }, getId, file)) as NormalizedAst<OtherInfo & ParentInformation>;
 		dataflow = processDataflowFor(normalized.ast, {
 			...data,
 			currentRequest: request,

--- a/src/dataflow/internal/process/functions/call/built-in/built-in-vector.ts
+++ b/src/dataflow/internal/process/functions/call/built-in/built-in-vector.ts
@@ -8,7 +8,7 @@ import type { ContainerIndices, ContainerIndex, ContainerIndicesCollection } fro
 import type { DataflowInformation } from '../../../../../info';
 import type { DataflowProcessorInformation } from '../../../../../processor';
 import { processKnownFunctionCall } from '../known-call-handling';
-import { getConfig, isOverPointerAnalysisThreshold } from '../../../../../../config';
+import { isOverPointerAnalysisThreshold } from '../../../../../../config';
 import { resolveIndicesByName } from '../../../../../../util/containers';
 
 /**
@@ -27,7 +27,7 @@ export function processVector<OtherInfo>(
 ): DataflowInformation {
 	const fnCall = processKnownFunctionCall({ name, args, rootId, data, origin: 'builtin:vector' });
 
-	if(!getConfig().solver.pointerTracking) {
+	if(!data.config.solver.pointerTracking) {
 		return fnCall.information;
 	}
 
@@ -65,7 +65,7 @@ export function processVector<OtherInfo>(
 		}
 	}
 
-	if(isOverPointerAnalysisThreshold(vectorArgs.length)) {
+	if(isOverPointerAnalysisThreshold(data.config, vectorArgs.length)) {
 		return fnCall.information;
 	}
 

--- a/src/dataflow/internal/process/functions/process-parameter.ts
+++ b/src/dataflow/internal/process/functions/process-parameter.ts
@@ -26,7 +26,7 @@ export function processFunctionParameter<OtherInfo>(parameter: RParameter<OtherI
 	for(const writtenNode of writtenNodes) {
 		log.trace(`parameter ${writtenNode.name} (${writtenNode.nodeId}) is defined at id ${writtenNode.definedAt} with ${defaultValue === undefined ? 'no default value' : ' no default value'}`);
 		graph.setDefinitionOfVertex(writtenNode);
-		environment = define(writtenNode, false, environment);
+		environment = define(writtenNode, false, environment, data.config);
 
 		if(defaultValue !== undefined) {
 			if(parameter.defaultValue?.type === RType.FunctionDefinition) {

--- a/src/dataflow/processor.ts
+++ b/src/dataflow/processor.ts
@@ -11,6 +11,7 @@ import type { REnvironmentInformation } from './environments/environment';
 import type { RParseRequest } from '../r-bridge/retriever';
 import type { RNode } from '../r-bridge/lang-4.x/ast/model/model';
 import type { KnownParserType, Parser } from '../r-bridge/parser';
+import type { FlowrConfigOptions } from '../config';
 
 export interface DataflowProcessorInformation<OtherInfo> {
 	readonly parser:              Parser<KnownParserType>
@@ -40,7 +41,10 @@ export interface DataflowProcessorInformation<OtherInfo> {
 	 * The chain of control-flow {@link NodeId}s that lead to the current node (e.g., of known ifs).
 	 */
 	readonly controlDependencies: ControlDependency[] | undefined
-	
+	/**
+	 * The config
+	 */
+	readonly config:			           FlowrConfigOptions
 }
 
 export type DataflowProcessor<OtherInfo, NodeType extends RNodeWithParent<OtherInfo>> = (node: NodeType, data: DataflowProcessorInformation<OtherInfo>) => DataflowInformation

--- a/src/queries/base-query-format.ts
+++ b/src/queries/base-query-format.ts
@@ -1,5 +1,6 @@
 import type { NormalizedAst } from '../r-bridge/lang-4.x/ast/model/processing/decorate';
 import type { DataflowInformation } from '../dataflow/info';
+import type { FlowrConfigOptions } from '../config';
 
 export interface BaseQueryFormat {
 	/** used to select the query type :) */
@@ -17,4 +18,5 @@ export interface BaseQueryResult {
 export interface BasicQueryData {
 	readonly ast:      NormalizedAst;
 	readonly dataflow: DataflowInformation;
+	readonly config:   FlowrConfigOptions;
 }

--- a/src/queries/catalog/config-query/config-query-executor.ts
+++ b/src/queries/catalog/config-query/config-query-executor.ts
@@ -4,10 +4,8 @@ import type {
 	ConfigQueryResult
 } from './config-query-format';
 import type { BasicQueryData } from '../../base-query-format';
-import { getConfig } from '../../../config';
 
-
-export function executeConfigQuery(_: BasicQueryData, queries: readonly ConfigQuery[]): ConfigQueryResult {
+export function executeConfigQuery({ config }: BasicQueryData, queries: readonly ConfigQuery[]): ConfigQueryResult {
 	if(queries.length !== 1) {
 		log.warn('Config query expects only up to one query, but got', queries.length);
 	}
@@ -17,6 +15,6 @@ export function executeConfigQuery(_: BasicQueryData, queries: readonly ConfigQu
 			/* there is no sense in measuring a get */
 			timing: 0
 		},
-		config: getConfig()
+		config: config
 	};
 }

--- a/src/queries/catalog/dependencies-query/dependencies-query-executor.ts
+++ b/src/queries/catalog/dependencies-query/dependencies-query-executor.ts
@@ -249,7 +249,7 @@ function resolveBasedOnConfig(data: BasicQueryData, vertex: DataflowGraphVertexF
 		}
 	}
 
-	return resolveIdToValue(argument, { environment, graph: data.dataflow.graph, full });
+	return resolveIdToValue(data.config, argument, { environment, graph: data.dataflow.graph, full });
 }
 
 function unwrapRValue(value: RLogicalValue | RStringValue | RNumberValue | string | number | unknown): string | undefined {

--- a/src/queries/catalog/dependencies-query/dependencies-query-executor.ts
+++ b/src/queries/catalog/dependencies-query/dependencies-query-executor.ts
@@ -249,7 +249,7 @@ function resolveBasedOnConfig(data: BasicQueryData, vertex: DataflowGraphVertexF
 		}
 	}
 
-	return resolveIdToValue(data.config, argument, { environment, graph: data.dataflow.graph, full });
+	return resolveIdToValue(argument, { environment, graph: data.dataflow.graph, full }, data.config);
 }
 
 function unwrapRValue(value: RLogicalValue | RStringValue | RNumberValue | string | number | unknown): string | undefined {

--- a/src/queries/catalog/resolve-value-query/resolve-value-query-executor.ts
+++ b/src/queries/catalog/resolve-value-query/resolve-value-query-executor.ts
@@ -8,7 +8,7 @@ export function fingerPrintOfQuery(query: ResolveValueQuery): string {
 	return JSON.stringify(query);
 }
 
-export function executeResolveValueQuery({ dataflow: { graph }, ast }: BasicQueryData, queries: readonly ResolveValueQuery[]): ResolveValueQueryResult {
+export function executeResolveValueQuery({ dataflow: { graph }, ast, config }: BasicQueryData, queries: readonly ResolveValueQuery[]): ResolveValueQueryResult {
 	const start = Date.now();
 	const results: ResolveValueQueryResult['results'] = {};
 	for(const query of queries) {
@@ -20,7 +20,7 @@ export function executeResolveValueQuery({ dataflow: { graph }, ast }: BasicQuer
 		
 		const values = query.criteria
 			.map(criteria => slicingCriterionToId(criteria, ast.idMap))
-			.flatMap(ident => resolveIdToValue(ident, { graph, full: true, idMap: ast.idMap }) ?? []);
+			.flatMap(ident => resolveIdToValue(config, ident, { graph, full: true, idMap: ast.idMap }) ?? []);
 
 		results[key] = {
 			values: values ? [... new Set(values)] : []

--- a/src/queries/catalog/resolve-value-query/resolve-value-query-executor.ts
+++ b/src/queries/catalog/resolve-value-query/resolve-value-query-executor.ts
@@ -20,7 +20,7 @@ export function executeResolveValueQuery({ dataflow: { graph }, ast, config }: B
 		
 		const values = query.criteria
 			.map(criteria => slicingCriterionToId(criteria, ast.idMap))
-			.flatMap(ident => resolveIdToValue(config, ident, { graph, full: true, idMap: ast.idMap }) ?? []);
+			.flatMap(ident => resolveIdToValue(ident, { graph, full: true, idMap: ast.idMap }, config) ?? []);
 
 		results[key] = {
 			values: values ? [... new Set(values)] : []

--- a/src/queries/catalog/static-slice-query/static-slice-query-executor.ts
+++ b/src/queries/catalog/static-slice-query/static-slice-query-executor.ts
@@ -10,7 +10,7 @@ export function fingerPrintOfQuery(query: StaticSliceQuery): string {
 	return JSON.stringify(query);
 }
 
-export function executeStaticSliceQuery({ dataflow: { graph }, ast }: BasicQueryData, queries: readonly StaticSliceQuery[]): StaticSliceQueryResult {
+export function executeStaticSliceQuery({ dataflow: { graph }, ast, config }: BasicQueryData, queries: readonly StaticSliceQuery[]): StaticSliceQueryResult {
 	const start = Date.now();
 	const results: StaticSliceQueryResult['results'] = {};
 	for(const query of queries) {
@@ -20,7 +20,7 @@ export function executeStaticSliceQuery({ dataflow: { graph }, ast }: BasicQuery
 		}
 		const { criteria, noReconstruction, noMagicComments } = query;
 		const sliceStart = Date.now();
-		const slice = staticSlicing(graph, ast, criteria);
+		const slice = staticSlicing(graph, ast, criteria, config.solver.slicer?.threshold);
 		const sliceEnd = Date.now();
 		if(noReconstruction) {
 			results[key] = { slice: { ...slice, '.meta': { timing: sliceEnd - sliceStart } } };

--- a/src/r-bridge/lang-4.x/ast/parser/json/parser.ts
+++ b/src/r-bridge/lang-4.x/ast/parser/json/parser.ts
@@ -8,6 +8,7 @@ import type { NormalizerData } from '../main/normalizer-data';
 import type { ParseStepOutputTS } from '../../../../../core/steps/all/core/01-parse-tree-sitter';
 import { normalizeTreeSitterTreeToAst } from '../../../tree-sitter/tree-sitter-normalize';
 import type { ParseStepOutput } from '../../../../parser';
+import {FlowrConfigOptions, getEngineConfig} from "../../../../../config";
 
 export const parseLog = log.getSubLogger({ name: 'ast-parser' });
 
@@ -42,11 +43,13 @@ export function normalizeButNotDecorated(
  * Tree-Sitter pendant to {@link normalize}.
  */
 export function normalizeTreeSitter(
+	config: FlowrConfigOptions,
 	{ parsed }: ParseStepOutputTS,
 	getId: IdGenerator<NoInfo> = deterministicCountingIdGenerator(0),
 	file?: string
 ): NormalizedAst {
-	const result = decorateAst(normalizeTreeSitterTreeToAst(parsed), { getId, file });
+	const lax = getEngineConfig(config, 'tree-sitter')?.lax;
+	const result = decorateAst(normalizeTreeSitterTreeToAst(parsed, lax), { getId, file });
 	result.hasError = parsed.rootNode.hasError;
 	return result;
 }

--- a/src/r-bridge/lang-4.x/ast/parser/json/parser.ts
+++ b/src/r-bridge/lang-4.x/ast/parser/json/parser.ts
@@ -1,14 +1,15 @@
-import { prepareParsedData, convertPreparedParsedData } from './format';
+import { convertPreparedParsedData, prepareParsedData } from './format';
 import { log } from '../../../../../util/log';
 import type { IdGenerator, NormalizedAst } from '../../model/processing/decorate';
-import { decorateAst , deterministicCountingIdGenerator } from '../../model/processing/decorate';
+import { decorateAst, deterministicCountingIdGenerator } from '../../model/processing/decorate';
 import type { NoInfo, RNode } from '../../model/model';
 import { normalizeRootObjToAst } from '../main/internal/structure/normalize-root';
 import type { NormalizerData } from '../main/normalizer-data';
 import type { ParseStepOutputTS } from '../../../../../core/steps/all/core/01-parse-tree-sitter';
 import { normalizeTreeSitterTreeToAst } from '../../../tree-sitter/tree-sitter-normalize';
 import type { ParseStepOutput } from '../../../../parser';
-import {FlowrConfigOptions, getEngineConfig} from "../../../../../config";
+import type { FlowrConfigOptions } from '../../../../../config';
+import { getEngineConfig } from '../../../../../config';
 
 export const parseLog = log.getSubLogger({ name: 'ast-parser' });
 
@@ -43,9 +44,9 @@ export function normalizeButNotDecorated(
  * Tree-Sitter pendant to {@link normalize}.
  */
 export function normalizeTreeSitter(
-	config: FlowrConfigOptions,
 	{ parsed }: ParseStepOutputTS,
 	getId: IdGenerator<NoInfo> = deterministicCountingIdGenerator(0),
+	config: FlowrConfigOptions,
 	file?: string
 ): NormalizedAst {
 	const lax = getEngineConfig(config, 'tree-sitter')?.lax;

--- a/src/r-bridge/lang-4.x/tree-sitter/tree-sitter-executor.ts
+++ b/src/r-bridge/lang-4.x/tree-sitter/tree-sitter-executor.ts
@@ -2,7 +2,7 @@ import Parser from 'web-tree-sitter';
 import type { RParseRequest } from '../../retriever';
 import fs from 'fs';
 import type { SyncParser } from '../../parser';
-import {FlowrConfigOptions, getEngineConfig} from '../../../config';
+import type { TreeSitterEngineConfig } from '../../../config';
 import { log } from '../../../util/log';
 
 export const DEFAULT_TREE_SITTER_R_WASM_PATH = `${__dirname}/tree-sitter-r.wasm`;
@@ -24,8 +24,8 @@ export class TreeSitterExecutor implements SyncParser<Parser.Tree> {
 	 * @param overrideWasmPath - The path to the tree-sitter-r wasm file, which takes precedence over the config and default paths if set.
 	 * @param overrideTreeSitterWasmPath - The path to the tree-sitter wasm file, which takes precedence over the config and default paths if set.
 	 */
-	public static async initTreeSitter(config: FlowrConfigOptions, overrideWasmPath?: string, overrideTreeSitterWasmPath?: string): Promise<void> {
-		const treeSitterWasmPath = overrideTreeSitterWasmPath ?? getEngineConfig(config, 'tree-sitter')?.treeSitterWasmPath ?? DEFAULT_TREE_SITTER_WASM_PATH;
+	public static async initTreeSitter(config?: TreeSitterEngineConfig, overrideWasmPath?: string, overrideTreeSitterWasmPath?: string): Promise<void> {
+		const treeSitterWasmPath = overrideTreeSitterWasmPath ?? config?.treeSitterWasmPath ?? DEFAULT_TREE_SITTER_WASM_PATH;
 		// noinspection JSUnusedGlobalSymbols - this is used by emscripten, see https://emscripten.org/docs/api_reference/module.html
 		await Parser.init({
 			locateFile: (path: string, prefix: string) => {
@@ -39,7 +39,7 @@ export class TreeSitterExecutor implements SyncParser<Parser.Tree> {
 			print:    (s: string) => wasmLog.debug(s),
 			printErr: (s: string) => wasmLog.error(s)
 		});
-		const wasmPath = overrideWasmPath ?? getEngineConfig(config, 'tree-sitter')?.wasmPath ?? DEFAULT_TREE_SITTER_R_WASM_PATH;
+		const wasmPath = overrideWasmPath ?? config?.wasmPath ?? DEFAULT_TREE_SITTER_R_WASM_PATH;
 		TreeSitterExecutor.language = await Parser.Language.load(wasmPath);
 	}
 

--- a/src/r-bridge/lang-4.x/tree-sitter/tree-sitter-executor.ts
+++ b/src/r-bridge/lang-4.x/tree-sitter/tree-sitter-executor.ts
@@ -2,7 +2,7 @@ import Parser from 'web-tree-sitter';
 import type { RParseRequest } from '../../retriever';
 import fs from 'fs';
 import type { SyncParser } from '../../parser';
-import { getEngineConfig } from '../../../config';
+import {FlowrConfigOptions, getEngineConfig} from '../../../config';
 import { log } from '../../../util/log';
 
 export const DEFAULT_TREE_SITTER_R_WASM_PATH = `${__dirname}/tree-sitter-r.wasm`;
@@ -24,8 +24,8 @@ export class TreeSitterExecutor implements SyncParser<Parser.Tree> {
 	 * @param overrideWasmPath - The path to the tree-sitter-r wasm file, which takes precedence over the config and default paths if set.
 	 * @param overrideTreeSitterWasmPath - The path to the tree-sitter wasm file, which takes precedence over the config and default paths if set.
 	 */
-	public static async initTreeSitter(overrideWasmPath?: string, overrideTreeSitterWasmPath?: string): Promise<void> {
-		const treeSitterWasmPath = overrideTreeSitterWasmPath ?? getEngineConfig('tree-sitter')?.treeSitterWasmPath ?? DEFAULT_TREE_SITTER_WASM_PATH;
+	public static async initTreeSitter(config: FlowrConfigOptions, overrideWasmPath?: string, overrideTreeSitterWasmPath?: string): Promise<void> {
+		const treeSitterWasmPath = overrideTreeSitterWasmPath ?? getEngineConfig(config, 'tree-sitter')?.treeSitterWasmPath ?? DEFAULT_TREE_SITTER_WASM_PATH;
 		// noinspection JSUnusedGlobalSymbols - this is used by emscripten, see https://emscripten.org/docs/api_reference/module.html
 		await Parser.init({
 			locateFile: (path: string, prefix: string) => {
@@ -39,7 +39,7 @@ export class TreeSitterExecutor implements SyncParser<Parser.Tree> {
 			print:    (s: string) => wasmLog.debug(s),
 			printErr: (s: string) => wasmLog.error(s)
 		});
-		const wasmPath = overrideWasmPath ?? getEngineConfig('tree-sitter')?.wasmPath ?? DEFAULT_TREE_SITTER_R_WASM_PATH;
+		const wasmPath = overrideWasmPath ?? getEngineConfig(config, 'tree-sitter')?.wasmPath ?? DEFAULT_TREE_SITTER_R_WASM_PATH;
 		TreeSitterExecutor.language = await Parser.Language.load(wasmPath);
 	}
 

--- a/src/r-bridge/lang-4.x/tree-sitter/tree-sitter-normalize.ts
+++ b/src/r-bridge/lang-4.x/tree-sitter/tree-sitter-normalize.ts
@@ -15,7 +15,6 @@ import type { RSymbol } from '../ast/model/nodes/r-symbol';
 import type { RString } from '../ast/model/nodes/r-string';
 import { startAndEndsWith } from '../../../util/text/strings';
 import type { RParameter } from '../ast/model/nodes/r-parameter';
-import { getEngineConfig } from '../../../config';
 import { log } from '../../../util/log';
 
 type SyntaxAndRNode = [SyntaxNode, RNode];
@@ -23,8 +22,7 @@ type SyntaxAndRNode = [SyntaxNode, RNode];
 /**
  * @param tree - The tree to normalize
  */
-export function normalizeTreeSitterTreeToAst(tree: Tree): RExpressionList {
-	const lax = getEngineConfig('tree-sitter')?.lax;
+export function normalizeTreeSitterTreeToAst(tree: Tree, lax?: boolean): RExpressionList {
 	if(lax) {
 		makeTreeSitterLax();
 	} else {

--- a/src/r-bridge/shell.ts
+++ b/src/r-bridge/shell.ts
@@ -9,7 +9,7 @@ import { getPlatform } from '../util/os';
 import fs from 'fs';
 import type { DeepReadonly , AsyncOrSync } from 'ts-essentials';
 import { initCommand } from './init';
-import { getEngineConfig } from '../config';
+import type { RShellEngineConfig } from '../config';
 import { ts2r } from './lang-4.x/convert-values';
 import type { AsyncParser } from './parser';
 import type { RParseRequest } from './retriever';
@@ -110,10 +110,10 @@ export const DEFAULT_R_PATH = getPlatform() === 'windows' ? 'R.exe' : 'R';
 
 let DEFAULT_R_SHELL_OPTIONS: RShellOptions | undefined = undefined;
 
-export function getDefaultRShellOptions(): RShellOptions {
+export function getDefaultRShellOptions(config?: RShellEngineConfig): RShellOptions {
 	if(!DEFAULT_R_SHELL_OPTIONS) {
 		DEFAULT_R_SHELL_OPTIONS = {
-			pathToRExecutable:  getEngineConfig('r-shell')?.rPath ?? DEFAULT_R_PATH,
+			pathToRExecutable:  config?.rPath ?? DEFAULT_R_PATH,
 			// -s is a short form of --no-echo (and the old version --slave), but this one works in R 3 and 4
 			// (see https://github.com/wch/r-source/commit/f1ff49e74593341c74c20de9517f31a22c8bcb04)
 			commandLineOptions: ['--vanilla', '--quiet', '--no-save', '-s'],
@@ -148,8 +148,8 @@ export class RShell implements AsyncParser<string> {
 	// should never be more than one, but let's be sure
 	private tempDirs = new Set<string>();
 
-	public constructor(options?: Partial<RShellOptions>) {
-		this.options = { ...getDefaultRShellOptions(), ...options };
+	public constructor(config: RShellEngineConfig | undefined, options?: Partial<RShellOptions>) {
+		this.options = { ...getDefaultRShellOptions(config), ...options };
 		this.log = log.getSubLogger({ name: this.options.sessionName });
 
 		this.session = new RShellSession(this.options, this.log);

--- a/src/slicing/static/static-slicer.ts
+++ b/src/slicing/static/static-slicer.ts
@@ -14,7 +14,6 @@ import { initializeCleanEnvironments } from '../../dataflow/environments/environ
 import type { NodeId } from '../../r-bridge/lang-4.x/ast/model/processing/node-id';
 import { VertexType } from '../../dataflow/graph/vertex';
 import { shouldTraverseEdge, TraverseEdge } from '../../dataflow/graph/edge';
-import { getConfig } from '../../config';
 
 export const slicerLogger = log.getSubLogger({ name: 'slicer' });
 
@@ -33,7 +32,7 @@ export function staticSlicing(
 	graph: DataflowGraph,
 	{ idMap }: NormalizedAst,
 	criteria: SlicingCriteria,
-	threshold = getConfig().solver.slicer?.threshold ?? 75,
+	threshold = 75,
 	cache?: Map<Fingerprint, Set<NodeId>>
 ): Readonly<SliceResult> {
 	guard(criteria.length > 0, 'must have at least one seed id to calculate slice');


### PR DESCRIPTION
When your first PR touches like half of the project's files ✌🏽 

Remaining `getConfig()` call-sites:

```
        src/cli  (6 usages found)
            benchmark-helper-app.ts  (1 usage found)
                benchmark  (1 usage found)
                    62 let config = getConfig();
            export-quads-app.ts  (1 usage found)
                27 const shell = new RShell(getEngineConfig(getConfig(), 'r-shell'));
            flowr.ts  (1 usage found)
                createConfig  (1 usage found)
                    109 config = getConfig(options['config-file'] ?? defaultConfigFile);
            slicer-app.ts  (1 usage found)
                getSlice  (1 usage found)
                    48 const config = getConfig();
            statistics-app.ts  (1 usage found)
                28 void flowrScriptGetStats(scriptOptions, getConfig());
            statistics-helper-app.ts  (1 usage found)
                27 void getStatsForSingleFile(scriptOptions, getConfig());
```


Closes #1641 