### PR TITLE
[Bug] Initialize ast var before use in location-map query

### DIFF
--- a/src/queries/catalog/location-map-query/location-map-query-executor.ts
+++ b/src/queries/catalog/location-map-query/location-map-query-executor.ts
@@ -24,6 +24,7 @@ function fuzzyFindFile(node: RNodeWithParent | undefined, idMap: AstIdMap): stri
 }
 
 export async function executeLocationMapQuery({ analyzer }: BasicQueryData, queries: readonly LocationMapQuery[]): Promise<LocationMapQueryResult> {
+	const ast = await analyzer.normalize();
 	const start = Date.now();
 	const criteriaOfInterest = new Set(queries
 		.flatMap(q => q.ids ?? [])
@@ -42,7 +43,6 @@ export async function executeLocationMapQuery({ analyzer }: BasicQueryData, quer
 		count++;
 	}
 
-	const ast = await analyzer.normalize();
 	for(const [id, node] of ast.idMap.entries()) {
 		if(node.location && (criteriaOfInterest.size === 0 || criteriaOfInterest.has(id))) {
 			const file = fuzzyFindFile(node, ast.idMap);


### PR DESCRIPTION
Fixes a bug with the `ast` constant not being initialized within the `map` call.
This was not obvious because of the TDZ.

Before:

```
R> :query "[{\"type\":\"location-map\", \"ids\": [\"11@sum\"]}]" file://test/testfiles/example.R
2025-11-03 13:53:46.153 ERROR   /src/queries/query.ts:218       main
 ReferenceError  Cannot access 'ast' before initialization
error stack:
  • location-map-query-executor.ts
        /src/queries/catalog/location-map-query/location-map-query-executor.ts:30
```

After:

```
R> :query "[{\"type\":\"location-map\", \"ids\": [\"11@sum\"]}]" file://test/testfiles/example.R
Query: location-map (7 ms)
   ╰ File List:
      ╰ 0: `test/testfiles/example.R`
   ╰ Id List: {40}
All queries together required ≈13 ms (1ms accuracy, total 16 ms)
```