### PR TITLE
Tiny doc-fix: omit duplicate wiki url path

### DIFF
--- a/src/documentation/wiki-mk/doc-context.ts
+++ b/src/documentation/wiki-mk/doc-context.ts
@@ -352,7 +352,7 @@ export function makeDocContextForTypes(
 				link = i.url;
 				text ??= i.name;
 			} else {
-				link = `${FlowrWikiBaseRef}/${pageName.toLowerCase().replaceAll(' ', '-')}`;
+				link = `${FlowrGithubRef}/${pageName.toLowerCase().replaceAll(' ', '-')}`;
 			}
 			text ??= pageName.split('/').pop() ?? pageName;
 			return `[${text}](${link}${segment ? '#' + segment : ''})`;


### PR DESCRIPTION
Links to other Wiki pages created using `GeneralDocContext#linkPage` currently have an erroneous duplicate `wiki/` path segment.