### PR TITLE
feat(dataflow): track ellmer chat backends and live helpers as unknown side effects

### DIFF
--- a/src/dataflow/environments/default-builtin-config.ts
+++ b/src/dataflow/environments/default-builtin-config.ts
@@ -92,6 +92,22 @@ export const GgPlotAddons = [
 ];
 const PlotAddons = GraphicsPlotAddons.concat(GgPlotImplicitAddons, ...PlotFunctionsWithAddParam);
 
+/**
+ * Top-level entry points of the {@link https://ellmer.tidyverse.org/ ellmer} package.
+ * Every chat backend opens a network connection to a third-party LLM provider, and
+ * `live_console` / `live_browser` start an interactive REPL or browser session, so
+ * we treat every one of these as having unknown side effects (similar to `eval` or
+ * `load`). The `chat_*` family below mirrors the providers documented at
+ * {@link https://ellmer.tidyverse.org/reference/index.html#chat}.
+ */
+export const EllmerFunctions = [
+	'chat_anthropic', 'chat_aws_bedrock', 'chat_azure_openai', 'chat_cloudflare', 'chat_cortex_analyst',
+	'chat_databricks', 'chat_deepseek', 'chat_github', 'chat_google_gemini', 'chat_google_vertex',
+	'chat_groq', 'chat_huggingface', 'chat_mistral', 'chat_ollama', 'chat_openai', 'chat_openrouter',
+	'chat_perplexity', 'chat_portkey', 'chat_snowflake', 'chat_vllm',
+	'live_console', 'live_browser'
+];
+
 const RegexConvIn = /[-/\\^$*+?.()|[\]{}]/g;
 function toRegex(n: readonly string[]): RegExp {
 	return new RegExp(`^(${
@@ -223,6 +239,7 @@ export const DefaultBuiltinConfig = [
 		}, assumePrimitive: true },
 	{ type: 'function', names: ['('],                                          processor: BuiltInProcName.Default,             config: { returnsNthArgument: 0 },                                                     assumePrimitive: true  },
 	{ type: 'function', names: ['load', 'load_all', 'setwd', 'set.seed'],      processor: BuiltInProcName.Default,             config: { hasUnknownSideEffects: true, forceArgs: [true] },                            assumePrimitive: false },
+	{ type: 'function', names: EllmerFunctions,                                processor: BuiltInProcName.Default,             config: { hasUnknownSideEffects: true, forceArgs: 'all' },                             assumePrimitive: false },
 	{ type: 'function', names: ['body', 'formals', 'environment'],             processor: BuiltInProcName.Default,             config: { hasUnknownSideEffects: true, forceArgs: [true] },                            assumePrimitive: true },
 	{ type:      'function',
 		names:     ['.Call', '.External', '.C', '.Fortran'],


### PR DESCRIPTION
Closes #2467

Adds an `EllmerFunctions` named array (matching the convention used for `GgPlotCreate`, `TinyPlotCrate`, etc.) and a new row in `DefaultBuiltinConfig` that marks every ellmer top-level entry point as `hasUnknownSideEffects: true`. Same treatment as the existing `load` / `setwd` / `set.seed` row, just one line below it.

## Why

ellmer's `chat_*` family opens a network connection to a third-party LLM provider (or local Ollama / vLLM endpoint), and `live_console` / `live_browser` start an interactive REPL or browser session. flowr's dataflow analysis can't model the side effects of any of those calls, so they should be treated the same way as `eval` and `load` — as the issue body says, "Similar to `eval` or `load` which we cannot handle fully".

## Provider list

The chat backends mirror ellmer's [reference index](https://ellmer.tidyverse.org/reference/index.html#chat):

`chat_anthropic`, `chat_aws_bedrock`, `chat_azure_openai`, `chat_cloudflare`, `chat_cortex_analyst`, `chat_databricks`, `chat_deepseek`, `chat_github`, `chat_google_gemini`, `chat_google_vertex`, `chat_groq`, `chat_huggingface`, `chat_mistral`, `chat_ollama`, `chat_openai`, `chat_openrouter`, `chat_perplexity`, `chat_portkey`, `chat_snowflake`, `chat_vllm`

Plus `live_console` and `live_browser` for the interactive helpers.

## `forceArgs: 'all'`

I picked `forceArgs: 'all'` (same as the `cat` row a few lines down) rather than `[true]` (the `load` style) because ellmer chat calls take a system prompt as positional arg 1 plus tools / params as named args — every argument can carry data the analysis shouldn't drop. Happy to switch to `[true]` if you'd rather match the `load` row exactly; let me know.

## What's intentionally NOT in this PR

- The `Chat$chat()` / `Chat$stream()` S7 methods on the resulting Chat object — those are tracked through the object's data flow, and the call-site is what gets flagged here. Adding S7 method names here would also flag unrelated namespace collisions.
- `params(...)`, `type_*`, `content_*`, `register_tool` — pure data constructors / registry helpers; no side effect on their own.
- ggplot2-style explicit add functions or wrapper packages around ellmer (chatlas, etc.) — out of scope per "ellmer and co" referring to ellmer itself, not third-party wrappers. Easy to extend later if you want.

## Verification

- `npx tsc --project . --noEmit` — clean.
- `git diff --stat upstream/main` — 17 lines added in one file.

