### PR TITLE
Support for compiler::*

### DIFF
--- a/src/dataflow/environments/default-builtin-config.ts
+++ b/src/dataflow/environments/default-builtin-config.ts
@@ -442,7 +442,8 @@ export const DefaultBuiltinConfig = [
 	{ type: 'function', names: ['Recall'],                                     processor: BuiltInProcName.Recall,              config: { libFn: true },                                                               assumePrimitive: false },
 	{ type: 'function', names: ['sys.function'],                               processor: BuiltInProcName.Recall,              config: { libFn: true, unknownOnNonZeroArg: true },                                    assumePrimitive: false },
 	{ type: 'function', names: ['c'],                                          processor: BuiltInProcName.Vector,              config: {},                                                                            assumePrimitive: true, evalHandler: 'built-in:c'  },
-	{ type: 'function', names: [Identifier.make('cmpfun', 'compiler'), Identifier.make('compile', 'compiler')],  processor: BuiltInProcName.Default, config: { returnsNthArgument: 0 } },
+	{ type: 'function', names: [Identifier.make('cmpfun', 'compiler'), Identifier.make('compile', 'compiler')], processor: BuiltInProcName.Default, config: { returnsNthArgument: 0 } },
+	{ type: 'function', names: [Identifier.make('loadcmp', 'compiler')],                                        processor: BuiltInProcName.Default, config: { hasUnknownSideEffects: true } },
 	{
 		type:      'function',
 		names:     ['setnames', 'setNames', 'setkey', 'setkeyv', 'setindex', 'setindexv', 'setattr'],

--- a/src/dataflow/environments/default-builtin-config.ts
+++ b/src/dataflow/environments/default-builtin-config.ts
@@ -442,6 +442,7 @@ export const DefaultBuiltinConfig = [
 	{ type: 'function', names: ['Recall'],                                     processor: BuiltInProcName.Recall,              config: { libFn: true },                                                               assumePrimitive: false },
 	{ type: 'function', names: ['sys.function'],                               processor: BuiltInProcName.Recall,              config: { libFn: true, unknownOnNonZeroArg: true },                                    assumePrimitive: false },
 	{ type: 'function', names: ['c'],                                          processor: BuiltInProcName.Vector,              config: {},                                                                            assumePrimitive: true, evalHandler: 'built-in:c'  },
+	{ type: 'function', names: [Identifier.make('cmpfun', 'compiler'), Identifier.make('compile', 'compiler')],  processor: BuiltInProcName.Default, config: { returnsNthArgument: 0 } },
 	{
 		type:      'function',
 		names:     ['setnames', 'setNames', 'setkey', 'setkeyv', 'setindex', 'setindexv', 'setattr'],
@@ -520,7 +521,7 @@ export const DefaultBuiltinConfig = [
 		config:   {
 			readIndices: false
 		}
-	}
+	},
 ] as const satisfies BuiltInDefinitions;
 
 

--- a/src/queries/catalog/dependencies-query/function-info/read-functions.ts
+++ b/src/queries/catalog/dependencies-query/function-info/read-functions.ts
@@ -113,4 +113,6 @@ export const ReadFunctions: FunctionInfo[] = [
 	{ package: 'openxlsx', name: 'loadWorkbook', argIdx: 0, argName: 'file', resolveValue: true },
 	{ package: 'readODS', name: 'read_ods', argIdx: 0, argName: 'path', resolveValue: true },
 	{ package: 'vroom', name: 'vroom', argIdx: 0, argName: 'file', resolveValue: true },
+	{ package: 'compiler', name: 'loadcmp', argIdx: 0, argName: 'file', resolveValue: true },
+	{ package: 'compiler', name: 'cmpfile', argIdx: 0, argName: 'infile', resolveValue: true }
 ] as const;

--- a/src/queries/catalog/dependencies-query/function-info/write-functions.ts
+++ b/src/queries/catalog/dependencies-query/function-info/write-functions.ts
@@ -122,5 +122,6 @@ export const WriteFunctions: FunctionInfo[] = [
 	{ package: 'vroom', name: 'vroom_write_lines', argIdx: 1, argName: 'file', resolveValue: true },
 	{ package: 'rio', name: 'export', argIdx: 1, argName: 'file', resolveValue: true },
 	{ package: 'rio', name: 'export_list', argIdx: 1, argName: 'file', resolveValue: true },
-	{ package: 'magick',  name: 'image_write', argIdx: 1, argName: 'path', resolveValue: true, ignoreIf: 'arg-missing' },
+	{ package: 'magick', name: 'image_write', argIdx: 1, argName: 'path', resolveValue: true, ignoreIf: 'arg-missing' },
+	{ package: 'compiler', name: 'cmpfile', argIdx: 1, argName: 'outfile', resolveValue: true }
 ] as const;


### PR DESCRIPTION
Add basic support for compiler::cmpfun and compiler::compiler. For now flowr understands that these functions at least return their first argument