### PR TITLE
Enforce source locations for linter rules

### DIFF
--- a/src/linter/linter-format.ts
+++ b/src/linter/linter-format.ts
@@ -106,6 +106,10 @@ export interface LintingResult {
 	 * The node ID or IDs involved in this linting result, if applicable.
 	 */
 	readonly involvedId: NodeId | NodeId[] | undefined
+	/**
+	 * The source location where this linting result occurs
+	 */
+	readonly loc:        SourceLocation;
 }
 
 

--- a/src/linter/rules/absolute-path.ts
+++ b/src/linter/rules/absolute-path.ts
@@ -31,7 +31,6 @@ import { RString } from '../../r-bridge/lang-4.x/ast/model/nodes/r-string';
 
 export interface AbsoluteFilePathResult extends LintingResult {
 	filePath: string,
-	loc:      SourceLocation
 }
 
 type SupportedWd = '@script' | '@home' | string;

--- a/src/linter/rules/dataframe-access-validation.ts
+++ b/src/linter/rules/dataframe-access-validation.ts
@@ -11,7 +11,7 @@ import type { FlowrSearchElements } from '../../search/flowr-search';
 import { Q } from '../../search/flowr-search-builder';
 import { Ternary } from '../../util/logic';
 import { type MergeableRecord } from '../../util/objects';
-import { SourceRange } from '../../util/range';
+import { SourceLocation } from '../../util/range';
 import { LintingPrettyPrintContext, LintingResultCertainty, LintingRuleCertainty, type LintingResult, type LintingRule } from '../linter-format';
 import { LintingRuleTag } from '../linter-tags';
 
@@ -30,15 +30,13 @@ interface DataFrameAccess {
 
 export interface DataFrameAccessValidationResult extends LintingResult {
 	/** The type of the data frame access ("column" or "row") */
-	type:     'column' | 'row',
+	readonly type:     'column' | 'row',
 	/** The name or index of the column or row being accessed in the data frame */
-	accessed: string | number,
+	readonly accessed: string | number,
 	/** The name of the function/operation used for the access (e.g. `$`, `[`, `[[`, but also `filter`, `select`, ...) */
-	access:   string,
+	readonly access:   string,
 	/** The variable/symbol name of the accessed data frame operand (`undefined` if operand is no symbol) */
-	operand?: string,
-	/** The source range in the code where the access occurs */
-	range:    SourceRange
+	readonly operand?: string,
 }
 
 export interface DataFrameAccessValidationConfig extends MergeableRecord {
@@ -117,7 +115,7 @@ export const DATA_FRAME_ACCESS_VALIDATION = {
 				involvedId: node?.info.id,
 				access:     node?.lexeme ?? '???',
 				...(operand?.type === RType.Symbol ? { operand: Identifier.getName(operand.content) } : {}),
-				range:      SourceRange.fromNode(node) ?? SourceRange.invalid(),
+				loc:        SourceLocation.fromNode(node) ?? SourceLocation.invalid(),
 				certainty:  LintingResultCertainty.Certain
 			}));
 
@@ -126,10 +124,10 @@ export const DATA_FRAME_ACCESS_VALIDATION = {
 	prettyPrint: {
 		[LintingPrettyPrintContext.Query]: result => `Access of ${result.type} ` +
 			(typeof result.accessed === 'string' ? `"${result.accessed}"` : result.accessed) + ' ' +
-			(result.operand === undefined ? `at \`${result.access}\`` : `of \`${result.operand}\``) + ` at ${SourceRange.format(result.range)}`,
+			(result.operand === undefined ? `at \`${result.access}\`` : `of \`${result.operand}\``) + ` at ${SourceLocation.format(result.loc)}`,
 		[LintingPrettyPrintContext.Full]: result => `Accessed ${result.type} ` +
 			(typeof result.accessed === 'string' ? `"${result.accessed}"` : result.accessed) + ' does not exist ' +
-			(result.operand === undefined ? `at \`${result.access}\`` : `in \`${result.operand}\``) + ` at ${SourceRange.format(result.range)}`
+			(result.operand === undefined ? `at \`${result.access}\`` : `in \`${result.operand}\``) + ` at ${SourceLocation.format(result.loc)}`
 	},
 	info: {
 		name:          'Dataframe Access Validation',

--- a/src/linter/rules/dead-code.ts
+++ b/src/linter/rules/dead-code.ts
@@ -15,9 +15,7 @@ import { type CfgSimplificationPassName, DefaultCfgSimplificationOrder } from '.
 import type { Writable } from 'ts-essentials';
 import { RoleInParent } from '../../r-bridge/lang-4.x/ast/model/processing/role';
 
-export interface DeadCodeResult extends LintingResult {
-	readonly loc: SourceLocation
-}
+export type DeadCodeResult = LintingResult;
 
 export interface DeadCodeConfig extends MergeableRecord {
 	/**

--- a/src/linter/rules/file-path-validity.ts
+++ b/src/linter/rules/file-path-validity.ts
@@ -11,8 +11,7 @@ import { LintingRuleTag } from '../linter-tags';
 import { Enrichment } from '../../search/search-executor/search-enrichers';
 
 export interface FilePathValidityResult extends LintingResult {
-	filePath: string,
-	loc:      SourceLocation
+	filePath: string
 }
 
 export interface FilePathValidityConfig extends MergeableRecord {

--- a/src/linter/rules/function-finder-util.ts
+++ b/src/linter/rules/function-finder-util.ts
@@ -18,7 +18,6 @@ import { Ternary } from '../../util/logic';
 
 export interface FunctionsResult extends LintingResult {
 	function: string
-	loc:      SourceLocation
 }
 
 export interface FunctionsMetadata extends MergeableRecord {

--- a/src/linter/rules/naming-convention.ts
+++ b/src/linter/rules/naming-convention.ts
@@ -22,8 +22,7 @@ export enum CasingConvention {
 
 export interface NamingConventionResult extends LintingResult {
 	name:           string,
-	detectedCasing: CasingConvention,
-	loc:            SourceLocation
+	detectedCasing: CasingConvention
 }
 
 /**

--- a/src/linter/rules/problematic-inputs.ts
+++ b/src/linter/rules/problematic-inputs.ts
@@ -102,7 +102,6 @@ function checkPipeInjection(nid: NodeId, loc: SourceLocation, name: string, sour
 
 export interface ProblematicInputsResult extends LintingResult {
 	name:         string
-	loc:          SourceLocation
 	sources:      InputSources
 	pipeCommand?: string
 }

--- a/src/linter/rules/roxygen-arguments.ts
+++ b/src/linter/rules/roxygen-arguments.ts
@@ -22,7 +22,6 @@ import type { AstIdMap } from '../../r-bridge/lang-4.x/ast/model/processing/deco
 import type { RNode } from '../../r-bridge/lang-4.x/ast/model/model';
 
 export interface RoxygenArgsResult extends LintingResult {
-	readonly loc:              SourceLocation
 	readonly overDocumented?:  string[]
 	readonly underDocumented?: string[]
 }

--- a/src/linter/rules/seeded-randomness.ts
+++ b/src/linter/rules/seeded-randomness.ts
@@ -32,7 +32,6 @@ import { BuiltInProcName } from '../../dataflow/environments/built-in-proc-name'
 
 export interface SeededRandomnessResult extends LintingResult {
 	function: string
-	loc:      SourceLocation
 }
 
 export interface SeededRandomnessConfig extends MergeableRecord {

--- a/src/linter/rules/stop-with-call-arg.ts
+++ b/src/linter/rules/stop-with-call-arg.ts
@@ -18,9 +18,7 @@ import { getOriginInDfg, OriginType } from '../../dataflow/origin/dfg-get-origin
 import { pMatch } from '../../dataflow/internal/linker';
 import { valueSetGuard } from '../../dataflow/eval/values/general';
 
-export interface StopWithCallResult extends LintingResult {
-	readonly loc: SourceLocation
-}
+export type StopWithCallResult = LintingResult;
 
 export type StopWithCallConfig = MergeableRecord;
 

--- a/src/linter/rules/unused-definition.ts
+++ b/src/linter/rules/unused-definition.ts
@@ -14,8 +14,7 @@ import type { NormalizedAst, ParentInformation } from '../../r-bridge/lang-4.x/a
 import { RoleInParent } from '../../r-bridge/lang-4.x/ast/model/processing/role';
 
 export interface UnusedDefinitionResult extends LintingResult {
-	variableName?: string,
-	loc:           SourceLocation
+	variableName?: string
 }
 
 export interface UnusedDefinitionConfig extends MergeableRecord {

--- a/src/linter/rules/useless-loop.ts
+++ b/src/linter/rules/useless-loop.ts
@@ -8,8 +8,7 @@ import { LintingRuleTag } from '../linter-tags';
 import type { BuiltInProcName } from '../../dataflow/environments/built-in-proc-name';
 
 export interface UselessLoopResult extends LintingResult {
-	name: string,
-	loc:  SourceLocation
+	name: string
 }
 
 export interface UselessLoopConfig extends MergeableRecord {

--- a/src/util/range.ts
+++ b/src/util/range.ts
@@ -235,9 +235,9 @@ export const SourceLocation = {
 	 * @returns undefined if the given range is undefined
 	 * @see {@link SourceRange.fromNode} for getting the range from an AST node
 	 */
-	fromNode<OtherInfo>(this: void, node: RNode<OtherInfo>): SourceLocation | undefined {
+	fromNode<OtherInfo>(this: void, node: RNode<OtherInfo> | undefined): SourceLocation | undefined {
 		const range = SourceRange.fromNode(node);
-		return range !== undefined ? SourceLocation.from(range, node.info.file) : undefined;
+		return node !== undefined && range !== undefined ? SourceLocation.from(range, node.info.file) : undefined;
 	},
 	/**
 	 * Maps the file part of a {@link SourceLocation|source location} using the given mapper function.

--- a/test/functionality/linter/lint-dataframe-access-validation.test.ts
+++ b/test/functionality/linter/lint-dataframe-access-validation.test.ts
@@ -96,52 +96,52 @@ print(df3${access})
 			type ExpectedLinterResult = Omit<DataFrameAccessValidationResult, 'certainty' | 'quickFix' | 'involvedId'>;
 
 			const testCases: [string, ExpectedLinterResult][] = [
-				['df <- data.frame(id = 1:5, name = "A")\ndf$score', { type: 'column', accessed: 'score', access: '$', operand: 'df', range: SourceRange.from(2, 1, 2, 8) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf["level"]', { type: 'column', accessed: 'level', access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 11) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[["type"]]', { type: 'column', accessed: 'type', access: '[[', operand: 'df', range: SourceRange.from(2, 1, 2, 12) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[[4]]', { type: 'column', accessed: 4, access: '[[', operand: 'df', range: SourceRange.from(2, 1, 2, 7) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[2:3]', { type: 'column', accessed: 3, access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 7) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[-3]', { type: 'column', accessed: 3, access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 6) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[7, ]', { type: 'row', accessed: 7, access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 7) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[c(1, 3)]', { type: 'column', accessed: 3, access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 11) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[c(4, 8), ]', { type: 'row', accessed: 8, access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 13) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[[5, 4]]', { type: 'column', accessed: 4, access: '[[', operand: 'df', range: SourceRange.from(2, 1, 2, 10) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[[6, 2]]', { type: 'row', accessed: 6, access: '[[', operand: 'df', range: SourceRange.from(2, 1, 2, 10) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[3, "score"]', { type: 'column', accessed: 'score', access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 14) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[1:5, c(1, 3)]', { type: 'column', accessed: 3, access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 16) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[1:6, c(1, 2)]', { type: 'row', accessed: 6, access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 16) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndf[-c(4, 6), ]', { type: 'row', accessed: 6, access: '[', operand: 'df', range: SourceRange.from(2, 1, 2, 14) }],
-				['df <- data.frame(id = 1:5, name = "A")\nsubset(df, score > 50)', { type: 'column', accessed: 'score', access: 'subset', operand: 'df', range: SourceRange.from(2, 1, 2, 22) }],
-				['df <- data.frame(id = 1:5, name = "A")\nsubset(df, select = score)', { type: 'column', accessed: 'score', access: 'subset', operand: 'df', range: SourceRange.from(2, 1, 2, 26) }],
-				['df <- data.frame(id = 1:5, name = "A")\nsubset(df, select = 4)', { type: 'column', accessed: 4, access: 'subset', operand: 'df', range: SourceRange.from(2, 1, 2, 22) }],
-				['df <- data.frame(id = 1:5, name = "A")\nsubset(df, select = c(id, score))', { type: 'column', accessed: 'score', access: 'subset', operand: 'df', range: SourceRange.from(2, 1, 2, 33) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndplyr::filter(df, age > 30)', { type: 'column', accessed: 'age', access: 'dplyr::filter', operand: 'df', range: SourceRange.from(2, 1, 2, 27) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, id, score)', { type: 'column', accessed: 'score', access: 'dplyr::select', operand: 'df', range: SourceRange.from(2, 1, 2, 28) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, 2, 4)', { type: 'column', accessed: 4, access: 'dplyr::select', operand: 'df', range: SourceRange.from(2, 1, 2, 23) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, c(id, score))', { type: 'column', accessed: 'score', access: 'dplyr::select', operand: 'df', range: SourceRange.from(2, 1, 2, 31) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, 2:3)', { type: 'column', accessed: 3, access: 'dplyr::select', operand: 'df', range: SourceRange.from(2, 1, 2, 22) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, c(1, 4))', { type: 'column', accessed: 4, access: 'dplyr::select', operand: 'df', range: SourceRange.from(2, 1, 2, 26) }],
-				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, id, -level)', { type: 'column', accessed: 'level', access: 'dplyr::select', operand: 'df', range: SourceRange.from(2, 1, 2, 29) }],
-				['df <- data.frame(id = 1:5, level = 6:10)\ndplyr::mutate(df, score = value^2)', { type: 'column', accessed: 'value', access: 'dplyr::mutate', operand: 'df', range: SourceRange.from(2, 1, 2, 34) }],
-				['df <- data.frame(id = 1:5, level = 6:10)\ndplyr::mutate(df, avg = mean(age), score = level^2)', { type: 'column', accessed: 'age', access: 'dplyr::mutate', operand: 'df', range: SourceRange.from(2, 1, 2, 51) }],
-				['df1 <- data.frame(id = 1:5, name = "A")\ndf2 <- data.frame(id = 5:8)\nmerge(df1, df2, by = "key")', { type: 'column', accessed: 'key', access: 'merge', operand: 'df1', range: SourceRange.from(3, 1, 3, 27) }],
-				['df1 <- data.frame(id = 1:5, name = "A")\ndf2 <- data.frame(id = 5:8, name = "B")\nmerge(df1, df2, by = c("id", "type"))', { type: 'column', accessed: 'type', access: 'merge', operand: 'df1', range: SourceRange.from(3, 1, 3, 37) }],
-				[exampleCode({ filter: 'skill' }), { type: 'column', accessed: 'skill', access: 'filter', operand: 'df1', range: SourceRange.from(13, 5, 13, 22) }],
-				[exampleCode({ mutate: 'value' }), { type: 'column', accessed: 'value', access: 'mutate', range: SourceRange.from(14, 5, 14, 27) }],
-				[exampleCode({ join: 'key' }), { type: 'column', accessed: 'key', access: 'left_join', range: SourceRange.from(15, 5, 15, 30) }],
-				[exampleCode({ select: 'name' }), { type: 'column', accessed: 'name', access: 'select', range: SourceRange.from(16, 5, 16, 17) }],
-				[exampleCode({ select: 6 }), { type: 'column', accessed: 6, access: 'select', range: SourceRange.from(16, 5, 16, 14) }],
-				[exampleCode({ access: '$age' }), { type: 'column', accessed: 'age', access: '$', operand: 'df3', range: SourceRange.from(18, 7, 18, 13) }],
-				[exampleCode({ access: '[, "skill"]' }), { type: 'column', accessed: 'skill', access: '[', operand: 'df3', range: SourceRange.from(18, 7, 18, 20) }],
-				[exampleCode({ access: '[["name"]]' }), { type: 'column', accessed: 'name', access: '[[', operand: 'df3', range: SourceRange.from(18, 7, 18, 19) }],
-				[exampleCode({ access: '[5]' }), { type: 'column', accessed: 5, access: '[', operand: 'df3', range: SourceRange.from(18, 7, 18, 12) }],
-				[exampleCode({ access: '[[12]]' }), { type: 'column', accessed: 12, access: '[[', operand: 'df3', range: SourceRange.from(18, 7, 18, 15) }],
-				[exampleCode({ access: '[7, ]' }), { type: 'row', accessed: 7, access: '[', operand: 'df3', range: SourceRange.from(18, 7, 18, 14) }],
-				[exampleCode({ access: '[5, 6]' }), { type: 'column', accessed: 6, access: '[', operand: 'df3', range: SourceRange.from(18, 7, 18, 15) }],
-				[exampleCode({ access: '[8, 4]' }), { type: 'row', accessed: 8, access: '[', operand: 'df3', range: SourceRange.from(18, 7, 18, 15) }],
-				[exampleCode({ access: '[3:5]' }), { type: 'column', accessed: 5, access: '[', operand: 'df3', range: SourceRange.from(18, 7, 18, 14) }],
-				[exampleCode({ access: '[3:5, c(2, 8)]' }), { type: 'column', accessed: 8, access: '[', operand: 'df3', range: SourceRange.from(18, 7, 18, 23) }],
-				[exampleCode({ access: '[3:7, c(1, 3)]' }), { type: 'row', accessed: 7, access: '[', operand: 'df3', range: SourceRange.from(18, 7, 18, 23) }]
+				['df <- data.frame(id = 1:5, name = "A")\ndf$score', { type: 'column', accessed: 'score', access: '$', operand: 'df', loc: SourceRange.from(2, 1, 2, 8) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf["level"]', { type: 'column', accessed: 'level', access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 11) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[["type"]]', { type: 'column', accessed: 'type', access: '[[', operand: 'df', loc: SourceRange.from(2, 1, 2, 12) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[[4]]', { type: 'column', accessed: 4, access: '[[', operand: 'df', loc: SourceRange.from(2, 1, 2, 7) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[2:3]', { type: 'column', accessed: 3, access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 7) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[-3]', { type: 'column', accessed: 3, access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 6) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[7, ]', { type: 'row', accessed: 7, access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 7) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[c(1, 3)]', { type: 'column', accessed: 3, access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 11) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[c(4, 8), ]', { type: 'row', accessed: 8, access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 13) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[[5, 4]]', { type: 'column', accessed: 4, access: '[[', operand: 'df', loc: SourceRange.from(2, 1, 2, 10) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[[6, 2]]', { type: 'row', accessed: 6, access: '[[', operand: 'df', loc: SourceRange.from(2, 1, 2, 10) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[3, "score"]', { type: 'column', accessed: 'score', access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 14) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[1:5, c(1, 3)]', { type: 'column', accessed: 3, access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 16) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[1:6, c(1, 2)]', { type: 'row', accessed: 6, access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 16) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndf[-c(4, 6), ]', { type: 'row', accessed: 6, access: '[', operand: 'df', loc: SourceRange.from(2, 1, 2, 14) }],
+				['df <- data.frame(id = 1:5, name = "A")\nsubset(df, score > 50)', { type: 'column', accessed: 'score', access: 'subset', operand: 'df', loc: SourceRange.from(2, 1, 2, 22) }],
+				['df <- data.frame(id = 1:5, name = "A")\nsubset(df, select = score)', { type: 'column', accessed: 'score', access: 'subset', operand: 'df', loc: SourceRange.from(2, 1, 2, 26) }],
+				['df <- data.frame(id = 1:5, name = "A")\nsubset(df, select = 4)', { type: 'column', accessed: 4, access: 'subset', operand: 'df', loc: SourceRange.from(2, 1, 2, 22) }],
+				['df <- data.frame(id = 1:5, name = "A")\nsubset(df, select = c(id, score))', { type: 'column', accessed: 'score', access: 'subset', operand: 'df', loc: SourceRange.from(2, 1, 2, 33) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndplyr::filter(df, age > 30)', { type: 'column', accessed: 'age', access: 'dplyr::filter', operand: 'df', loc: SourceRange.from(2, 1, 2, 27) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, id, score)', { type: 'column', accessed: 'score', access: 'dplyr::select', operand: 'df', loc: SourceRange.from(2, 1, 2, 28) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, 2, 4)', { type: 'column', accessed: 4, access: 'dplyr::select', operand: 'df', loc: SourceRange.from(2, 1, 2, 23) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, c(id, score))', { type: 'column', accessed: 'score', access: 'dplyr::select', operand: 'df', loc: SourceRange.from(2, 1, 2, 31) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, 2:3)', { type: 'column', accessed: 3, access: 'dplyr::select', operand: 'df', loc: SourceRange.from(2, 1, 2, 22) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, c(1, 4))', { type: 'column', accessed: 4, access: 'dplyr::select', operand: 'df', loc: SourceRange.from(2, 1, 2, 26) }],
+				['df <- data.frame(id = 1:5, name = "A")\ndplyr::select(df, id, -level)', { type: 'column', accessed: 'level', access: 'dplyr::select', operand: 'df', loc: SourceRange.from(2, 1, 2, 29) }],
+				['df <- data.frame(id = 1:5, level = 6:10)\ndplyr::mutate(df, score = value^2)', { type: 'column', accessed: 'value', access: 'dplyr::mutate', operand: 'df', loc: SourceRange.from(2, 1, 2, 34) }],
+				['df <- data.frame(id = 1:5, level = 6:10)\ndplyr::mutate(df, avg = mean(age), score = level^2)', { type: 'column', accessed: 'age', access: 'dplyr::mutate', operand: 'df', loc: SourceRange.from(2, 1, 2, 51) }],
+				['df1 <- data.frame(id = 1:5, name = "A")\ndf2 <- data.frame(id = 5:8)\nmerge(df1, df2, by = "key")', { type: 'column', accessed: 'key', access: 'merge', operand: 'df1', loc: SourceRange.from(3, 1, 3, 27) }],
+				['df1 <- data.frame(id = 1:5, name = "A")\ndf2 <- data.frame(id = 5:8, name = "B")\nmerge(df1, df2, by = c("id", "type"))', { type: 'column', accessed: 'type', access: 'merge', operand: 'df1', loc: SourceRange.from(3, 1, 3, 37) }],
+				[exampleCode({ filter: 'skill' }), { type: 'column', accessed: 'skill', access: 'filter', operand: 'df1', loc: SourceRange.from(13, 5, 13, 22) }],
+				[exampleCode({ mutate: 'value' }), { type: 'column', accessed: 'value', access: 'mutate', loc: SourceRange.from(14, 5, 14, 27) }],
+				[exampleCode({ join: 'key' }), { type: 'column', accessed: 'key', access: 'left_join', loc: SourceRange.from(15, 5, 15, 30) }],
+				[exampleCode({ select: 'name' }), { type: 'column', accessed: 'name', access: 'select', loc: SourceRange.from(16, 5, 16, 17) }],
+				[exampleCode({ select: 6 }), { type: 'column', accessed: 6, access: 'select', loc: SourceRange.from(16, 5, 16, 14) }],
+				[exampleCode({ access: '$age' }), { type: 'column', accessed: 'age', access: '$', operand: 'df3', loc: SourceRange.from(18, 7, 18, 13) }],
+				[exampleCode({ access: '[, "skill"]' }), { type: 'column', accessed: 'skill', access: '[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 20) }],
+				[exampleCode({ access: '[["name"]]' }), { type: 'column', accessed: 'name', access: '[[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 19) }],
+				[exampleCode({ access: '[5]' }), { type: 'column', accessed: 5, access: '[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 12) }],
+				[exampleCode({ access: '[[12]]' }), { type: 'column', accessed: 12, access: '[[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 15) }],
+				[exampleCode({ access: '[7, ]' }), { type: 'row', accessed: 7, access: '[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 14) }],
+				[exampleCode({ access: '[5, 6]' }), { type: 'column', accessed: 6, access: '[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 15) }],
+				[exampleCode({ access: '[8, 4]' }), { type: 'row', accessed: 8, access: '[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 15) }],
+				[exampleCode({ access: '[3:5]' }), { type: 'column', accessed: 5, access: '[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 14) }],
+				[exampleCode({ access: '[3:5, c(2, 8)]' }), { type: 'column', accessed: 8, access: '[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 23) }],
+				[exampleCode({ access: '[3:7, c(1, 3)]' }), { type: 'row', accessed: 7, access: '[', operand: 'df3', loc: SourceRange.from(18, 7, 18, 23) }]
 			];
 
 			for(const [test, result] of testCases) {
@@ -157,7 +157,7 @@ print(df3${access})
 				parser,
 				'df <- data.frame(id = 1:3, name = c("Alice", "Bob", "Charlie"), score = c(90, 65, 75))\nprint(df$skill)',
 				'dataframe-access-validation',
-				[{ type: 'column', accessed: 'skill', access: '$', operand: 'df', range: [2, 7, 2, 14], certainty: LintingResultCertainty.Certain }]
+				[{ type: 'column', accessed: 'skill', access: '$', operand: 'df', loc: [2, 7, 2, 14], certainty: LintingResultCertainty.Certain }]
 			);
 
 			/** We expect the linter to report an issue, if a column is accessed by index via `[` or `[[` that does not exist in the data frame. */
@@ -166,7 +166,7 @@ print(df3${access})
 				parser,
 				'df <- data.frame(id = 1:3, name = c("Alice", "Bob", "Charlie"), score = c(90, 65, 75))\nprint(df[3:4])',
 				'dataframe-access-validation',
-				[{ type: 'column', accessed: 4, access: '[', operand: 'df', range: [2, 7, 2, 13], certainty: LintingResultCertainty.Certain }]
+				[{ type: 'column', accessed: 4, access: '[', operand: 'df', loc: [2, 7, 2, 13], certainty: LintingResultCertainty.Certain }]
 			);
 
 			/** We expect the linter to report an issue, if a row is accessed by index via `[` or `[[` that does not exist in the data frame. */
@@ -175,7 +175,7 @@ print(df3${access})
 				parser,
 				'df <- data.frame(id = 1:3, name = c("Alice", "Bob", "Charlie"), score = c(90, 65, 75))\nprint(df[[5, "score"]])',
 				'dataframe-access-validation',
-				[{ type: 'row', accessed: 5, access: '[[', operand: 'df', range: [2, 7, 2, 22], certainty: LintingResultCertainty.Certain }]
+				[{ type: 'row', accessed: 5, access: '[[', operand: 'df', loc: [2, 7, 2, 22], certainty: LintingResultCertainty.Certain }]
 			);
 
 			/** We expect the linter to report an issue, if a column is used in a `filter` function call that does not exist in the data frame. */
@@ -184,7 +184,7 @@ print(df3${access})
 				parser,
 				'df <- data.frame(id = 1:3, name = c("Alice", "Bob", "Charlie"), score = c(90, 65, 75))\ndf <- dplyr::filter(df, level > 70)',
 				'dataframe-access-validation',
-				[{ type: 'column', accessed: 'level', access: 'dplyr::filter', operand: 'df', range: [2, 7, 2, 35], certainty: LintingResultCertainty.Certain }]
+				[{ type: 'column', accessed: 'level', access: 'dplyr::filter', operand: 'df', loc: [2, 7, 2, 35], certainty: LintingResultCertainty.Certain }]
 			);
 
 			/** We expect the linter to report an issue, if a column is selected or unselected in a `select` function that does not exist in the data frame. */
@@ -193,7 +193,7 @@ print(df3${access})
 				parser,
 				'df <- data.frame(id = 1:3, name = c("Alice", "Bob", "Charlie"), score = c(90, 65, 75))\ndf <- dplyr::select(df, id, age, score)',
 				'dataframe-access-validation',
-				[{ type: 'column', accessed: 'age', access: 'dplyr::select', operand: 'df', range: [2, 7, 2, 39], certainty: LintingResultCertainty.Certain }]
+				[{ type: 'column', accessed: 'age', access: 'dplyr::select', operand: 'df', loc: [2, 7, 2, 39], certainty: LintingResultCertainty.Certain }]
 			);
 
 			/** We expect the linter to report an issue for all non-existent columns accessed in transformation functions like `filter`, `mutate`, and `select`, as well as all non-existent columns and rows accessed via access operators like `[`. */
@@ -203,11 +203,11 @@ print(df3${access})
 				'library(dplyr)\n\ndf1 <- data.frame(\n    id = c(1, 2, 3, 4),\n    score = c(65, 85, 40, 90)\n)\n\ndf2 <- df1 %>%\n    filter(age > 50) %>%\n    mutate(level = skill^2) %>%\n    select(-name)\n\nprint(df2[1:5, 3])',
 				'dataframe-access-validation',
 				[
-					{ type: 'column', accessed: 'age', access: 'filter', operand: 'df1', range: [9, 5, 9, 20], certainty: LintingResultCertainty.Certain },
-					{ type: 'column', accessed: 'skill', access: 'mutate', range: [10, 5, 10, 27], certainty: LintingResultCertainty.Certain },
-					{ type: 'column', accessed: 'name', access: 'select', range: [11, 5, 11, 17], certainty: LintingResultCertainty.Certain },
-					{ type: 'row', accessed: 5, access: '[', operand: 'df2', range: [13, 7, 13, 17], certainty: LintingResultCertainty.Certain },
-					{ type: 'column', accessed: 3, access: '[', operand: 'df2', range: [13, 7, 13, 17], certainty: LintingResultCertainty.Certain }
+					{ type: 'column', accessed: 'age', access: 'filter', operand: 'df1', loc: [9, 5, 9, 20], certainty: LintingResultCertainty.Certain },
+					{ type: 'column', accessed: 'skill', access: 'mutate', loc: [10, 5, 10, 27], certainty: LintingResultCertainty.Certain },
+					{ type: 'column', accessed: 'name', access: 'select', loc: [11, 5, 11, 17], certainty: LintingResultCertainty.Certain },
+					{ type: 'row', accessed: 5, access: '[', operand: 'df2', loc: [13, 7, 13, 17], certainty: LintingResultCertainty.Certain },
+					{ type: 'column', accessed: 3, access: '[', operand: 'df2', loc: [13, 7, 13, 17], certainty: LintingResultCertainty.Certain }
 				]
 			);
 		});


### PR DESCRIPTION
Enforce source locations for linter rule results to prevent that linter results are silently ignored [in the VSCode extension](https://github.com/flowr-analysis/vscode-flowr/blob/4963a5ed5f509495cd403ceff68b75efaddd8c74/src/lint.ts#L162)