### PR TITLE
2495 interval pentagon ai improve pentagon ram usage

### DIFF
--- a/src/abstract-interpretation/absint-condition-semantics.ts
+++ b/src/abstract-interpretation/absint-condition-semantics.ts
@@ -108,6 +108,8 @@ export function createConditionApplier<StateDomain extends AnyStateDomain<AnyAbs
 		[Identifier.make('('), unaryConditionSemanticsGuard(applyConditionSemantics), unaryConditionSemanticsGuard(applyNegatedConditionSemantics)],
 		[Identifier.make('||'), binaryConditionSemanticsGuard(orConditionSemantics), binaryConditionSemanticsGuard(negatedOrConditionSemantics)],
 		[Identifier.make('&&'), binaryConditionSemanticsGuard(andConditionSemantics), binaryConditionSemanticsGuard(negatedAndConditionSemantics)],
+		[Identifier.make('|'), binaryConditionSemanticsGuard(orConditionSemantics), binaryConditionSemanticsGuard(negatedOrConditionSemantics)],
+		[Identifier.make('&'), binaryConditionSemanticsGuard(andConditionSemantics), binaryConditionSemanticsGuard(negatedAndConditionSemantics)],
 	] as const satisfies ConditionSemanticsMapperInfo<StateDomain, Visitor>[];
 
 	function orConditionSemantics(leftNodeId: NodeId, rightNodeId: NodeId, state: StateDomain, visitor: Visitor, dfg: DataflowGraph): StateDomain {

--- a/src/abstract-interpretation/pentagon/closed-pentagon-domain.ts
+++ b/src/abstract-interpretation/pentagon/closed-pentagon-domain.ts
@@ -117,7 +117,7 @@ export class ClosedPentagonDomain extends StateAbstractDomain<ClosedPentagonValu
 		return result;
 	}
 
-	private static reduce(value: StateDomainLift<ClosedPentagonValueDomain>): StateDomainLift<ClosedPentagonValueDomain> {
+	public static reduce(value: StateDomainLift<ClosedPentagonValueDomain>): StateDomainLift<ClosedPentagonValueDomain> {
 		if(value === Bottom) {
 			return Bottom;
 		}

--- a/src/abstract-interpretation/pentagon/closed-pentagon-domain.ts
+++ b/src/abstract-interpretation/pentagon/closed-pentagon-domain.ts
@@ -1,6 +1,12 @@
 import { IntervalDomain } from '../domains/interval-domain';
 import type { NodeId } from '../../r-bridge/lang-4.x/ast/model/processing/node-id';
-import type { ConcreteState, StateDomainBottom, StateDomainLift, StateDomainTop } from '../domains/state-abstract-domain';
+import type {
+	ConcreteState,
+	StateDomainBottom,
+	StateDomainLift,
+	StateDomainTop,
+	StateDomainValue
+} from '../domains/state-abstract-domain';
 import { StateAbstractDomain } from '../domains/state-abstract-domain';
 import { UpperBoundsValueDomain } from './upper-bounds/upper-bounds-value-domain';
 import { Bottom, Top } from '../domains/lattice';
@@ -51,8 +57,122 @@ export class ClosedPentagonDomain extends StateAbstractDomain<ClosedPentagonValu
 		return value?.create(value.value);
 	}
 
+	public override equals(other: this): boolean {
+		return this.leq(other) && other.leq(this);
+	}
+
+	public override leq(other: this): boolean {
+		if(this.value === other.value || this.value === Bottom) {
+			return true;
+		} else if(other.value === Bottom || this.value.size > other.value.size) {
+			return false;
+		}
+		for(const [key, value] of this.value.entries()) {
+			const otherValue = other.get(key);
+
+			// If right is not defined, then we have not visited that element on the right side yet, so its not leq
+			if(isUndefined(otherValue)) {
+				return false;
+			}
+
+			// Leq is the case when for every element on the left holds that
+			// Interval of value leq interval of otherValue
+			// And upperbounds of left leq upper bounds of right (which equals right is subset of left)
+
+			// If interval leq does not hold, then leq over all does not hold
+			if(!(value.value.interval.leq(otherValue.value.interval))) {
+				return false;
+			}
+
+			// Early exit if the upper bounds of left and right side are equal, then leq is fine
+			if(value.value.upperBounds === otherValue.value.upperBounds) {
+				continue;
+			}
+
+			// Since both are not equal, if right side is Bottom, then leq is also not satisfiable
+			if(otherValue.value.upperBounds.value === Bottom) {
+				return false;
+			}
+
+			// At this point, left side could be bottom, right side has to be upper bounds
+			// Problem is, that the left side might have implicit upper bounds through intervals that are not explicit
+			// So for each upper bound on the right side, we must check if it is explicitly or implicitly present on the left
+			// If one is neither explicitly nor implicitly present, leq is not satisfiable and we return false
+			for(const rightUpperBound of otherValue.value.upperBounds.value.values()) {
+				// Is explicitly present on left side? => continue with next upper bound
+				if(value.value.upperBounds.has(rightUpperBound)) {
+					continue;
+				}
+				// Is implicitly present on left side?
+				const intervalA = value.value.interval;
+				const intervalB = this.value.get(rightUpperBound)?.value.interval;
+
+				// If the right interval does not exist, or any of both are bottom, then the upper bound cannot be implicitly present
+				if(intervalB === undefined || intervalA.value === Bottom || intervalB.value === Bottom) {
+					return false;
+				}
+
+				// It is implicitly present if intervalA <= intervalB and therefore the upper limit of A <= lower limit of B
+				if(intervalA.value[1] <= intervalB.value[0]) {
+					continue;
+				}
+				// The interval is not implicitly present, so leq is not satisfiable.
+				return false;
+			}
+		}
+		return true;
+	}
+
 	public override join(other: this): this {
-		return this.create(super.join(other).value);
+		if(this.value === Bottom){
+			return this.create(other.value);
+		} else if(other.value === Bottom) {
+			return this.create(this.value);
+		}
+		const result = this.create(this.value) as this & StateAbstractDomain<ClosedPentagonValueDomain, StateDomainValue<ClosedPentagonValueDomain>>;
+
+		for(const [key, value] of other.value.entries()) {
+			const currValue = result.get(key);
+
+			if(currValue === undefined) {
+				result.set(key, value);
+			} else {
+				const leftInterval = currValue.value.interval;
+				const rightInterval = value.value.interval;
+				const joinedInterval = leftInterval.join(rightInterval);
+
+				const leftUpperBounds = currValue.value.upperBounds;
+				const rightUpperBounds = value.value.upperBounds;
+				// For the upper bounds part, we:
+				// 1. Join both upper bounds
+				const joinedUpperBounds = leftUpperBounds.join(rightUpperBounds);
+				// 2. Add all upper bounds of the left, that are implicitly present on the right
+				if(leftUpperBounds.isValue() && rightInterval.isValue()) {
+					for(const leftUpperBound of leftUpperBounds.value) {
+						const intervalA = rightInterval;
+						const intervalB = other.value.get(leftUpperBound)?.value.interval;
+						if(intervalB !== undefined && intervalB.isValue() && intervalA.value[1] <= intervalB.value[0]) {
+							// The upper bound is implicitly present on both sides
+							joinedUpperBounds.add(leftUpperBound);
+						}
+					}
+				}
+				// 3. Add all upper bounds of the right, that are implicitly present on the left
+				if(rightUpperBounds.isValue() && leftInterval.isValue()) {
+					for(const rightUpperBound of rightUpperBounds.value) {
+						const intervalA = leftInterval;
+						const intervalB = result.get(rightUpperBound)?.value.interval;
+						if(intervalB !== undefined && intervalB.isValue() && intervalA.value[1] <= intervalB.value[0]) {
+							// The upper bound is implicitly present on both sides
+							joinedUpperBounds.add(rightUpperBound);
+						}
+					}
+				}
+
+				result.set(key, currValue.create({ interval: joinedInterval, upperBounds: joinedUpperBounds }));
+			}
+		}
+		return result;
 	}
 
 	public override meet(other: this): this {
@@ -127,31 +247,10 @@ export class ClosedPentagonDomain extends StateAbstractDomain<ClosedPentagonValu
 				return Bottom;
 			}
 
-			const newInferredBounds = new Set<NodeId>();
-			const removeBounds = new Set<NodeId>();
-			for(const [otherKey, otherPentagon] of value.entries()) {
-				if(key === otherKey) {
-					continue;
-				}
-				const keyInterval = pentagon.value.interval;
-				const otherKeyInterval = otherPentagon.value.interval;
-				if(!pentagon.value.upperBounds.has(otherKey) && keyInterval.isValue() && otherKeyInterval.isValue() && keyInterval.value[1] <= otherKeyInterval.value[0]) {
-					newInferredBounds.add(otherKey);
-				}
-			}
-
+			// If there is a self reference in the upper bounds, remove it
 			if(pentagon.value.upperBounds.has(key)) {
-				removeBounds.add(key);
-			}
-
-			if(newInferredBounds.size > 0 || removeBounds.size > 0) {
 				const reducedPentagon = pentagon.create(pentagon.value);
-				for(const bound of newInferredBounds.values()) {
-					reducedPentagon.value.upperBounds.add(bound);
-				}
-				for(const bound of removeBounds.values()) {
-					reducedPentagon.value.upperBounds.remove(bound);
-				}
+				reducedPentagon.value.upperBounds.remove(key);
 				(value as Map<NodeId, ClosedPentagonValueDomain>).set(key, reducedPentagon);
 			}
 		}

--- a/src/abstract-interpretation/pentagon/numeric-pentagon-inference.ts
+++ b/src/abstract-interpretation/pentagon/numeric-pentagon-inference.ts
@@ -77,11 +77,21 @@ export class NumericPentagonInferenceVisitor extends AbstractInterpretationVisit
 				this.currentState.set(target, targetPentagon);
 			}
 
-			// Remove information of all constants on the right hand side
+			// Remove information of all constants/expression results on the right hand side
 			this.currentState = this.removeConstantAndExpressionInfo(source);
 		}
 	}
 
+	/**
+	 * Removes all inferred information for expressions and constants in the state, that are part of the provided nodeId.
+	 * This is used for assignments, to remove any information on constants or expressions that are part of the source
+	 * part of the assignment to reduce the number of inferred values for the following inference steps
+	 * (as these information will not be referenced/required anymore, and will still be present in the traces of the
+	 * respective node if queried).
+	 * @param nodeId - The root node that contains the constant/expression infos to remove (should be source part of assignment).
+	 * @param state - Optional state to modify, defaults to this.currentState.
+	 * @private
+	 */
 	private removeConstantAndExpressionInfo(nodeId: NodeId, state?: ClosedPentagonDomain): ClosedPentagonDomain {
 		state ??= this.currentState;
 		const minifiedDomain = state.create(state.value);

--- a/src/abstract-interpretation/pentagon/numeric-pentagon-inference.ts
+++ b/src/abstract-interpretation/pentagon/numeric-pentagon-inference.ts
@@ -3,6 +3,7 @@ import type { AbsintVisitorConfiguration } from '../absint-visitor';
 import { AbstractInterpretationVisitor } from '../absint-visitor';
 import { ClosedPentagonValueDomain } from './closed-pentagon-value-domain';
 import type { DataflowGraphVertexFunctionCall, DataflowGraphVertexValue } from '../../dataflow/graph/vertex';
+import { isFunctionCallVertex, isValueVertex } from '../../dataflow/graph/vertex';
 import type { RNumber } from '../../r-bridge/lang-4.x/ast/model/nodes/r-number';
 import type { ParentInformation } from '../../r-bridge/lang-4.x/ast/model/processing/decorate';
 import { IntervalDomain } from '../domains/interval-domain';
@@ -16,6 +17,8 @@ import { getUpperBoundsConditionSemantics } from './upper-bounds/upper-bounds-co
 import type { AnyStateDomain } from '../domains/state-domain-like';
 import type { AnyAbstractDomain } from '../domains/abstract-domain';
 import { log } from '../../util/log';
+import { FunctionArgument } from '../../dataflow/graph/graph';
+import { Bottom } from '../domains/lattice';
 
 const numericInferenceLogger = log.getSubLogger({ name: 'numeric-pentagon-inference' });
 
@@ -73,7 +76,54 @@ export class NumericPentagonInferenceVisitor extends AbstractInterpretationVisit
 				this.currentState.set(sourceOrigin, sourcePentagon);
 				this.currentState.set(target, targetPentagon);
 			}
+
+			// Remove information of all constants on the right hand side
+			this.currentState = this.removeConstantAndExpressionInfo(source);
 		}
+	}
+
+	private removeConstantAndExpressionInfo(nodeId: NodeId, state?: ClosedPentagonDomain): ClosedPentagonDomain {
+		state ??= this.currentState;
+		const minifiedDomain = state.create(state.value);
+
+		const removeConstant = (nodeId: NodeId, state: ClosedPentagonDomain): NodeId[] => {
+			// Remove information of all constants on the right hand side
+			const rhsVertex = this.config.dfg.getVertex(nodeId);
+			if(isValueVertex(rhsVertex)) {
+				state.remove(nodeId);
+				return [nodeId];
+			} else if(isFunctionCallVertex(rhsVertex)) {
+				let removedNodeIds: NodeId[] = [];
+				for(const arg of rhsVertex.args.map(FunctionArgument.getReference).filter(isNotUndefined)) {
+					removedNodeIds = removedNodeIds.concat(removeConstant(arg, state));
+				}
+				state.remove(nodeId);
+				removedNodeIds.push(nodeId);
+				return removedNodeIds;
+			}
+			return [];
+		};
+
+		const removedNodeIds = new Set(removeConstant(nodeId, minifiedDomain));
+
+		if(minifiedDomain.value !== Bottom && removedNodeIds.size > 0) {
+			for(const [key, pentagon] of minifiedDomain.value.entries()) {
+				if(pentagon.value.upperBounds.isValue()) {
+					const upperBoundsToRemove = pentagon.value.upperBounds.value.intersection(removedNodeIds);
+					if(upperBoundsToRemove.size > 0) {
+						const reducedPentagon = pentagon.create(pentagon.value);
+						for(const bound of upperBoundsToRemove.values()) {
+							reducedPentagon.value.upperBounds.remove(bound);
+						}
+						// Manually set the value as we do not want to trigger the reduction for every set,
+						// as we apply the reduction at the end.
+						(minifiedDomain.value as Map<NodeId, ClosedPentagonValueDomain>).set(key, reducedPentagon);
+					}
+				}
+			}
+		}
+
+		return state.create(ClosedPentagonDomain.reduce(minifiedDomain.value));
 	}
 
 	protected override onNumberConstant({ vertex, node }: { vertex: DataflowGraphVertexValue, node: RNumber<ParentInformation> }) {
@@ -140,7 +190,7 @@ export class NumericPentagonInferenceVisitor extends AbstractInterpretationVisit
 			// As we currently cannot describe that we have upper bounds-info but not know whether it is a numeric scalar value, we cannot infer upper-bounds values for non-numeric scalar values.
 			return;
 		}
-		pentagon.value.upperBounds = value;
+		pentagon.value.upperBounds = value.create(value.value);
 		state.set(node, pentagon);
 	}
 
@@ -160,26 +210,24 @@ export class NumericPentagonInferenceVisitor extends AbstractInterpretationVisit
 	}
 
 	protected override applyConditionSemantics(state: ClosedPentagonDomain, conditionNodeId: NodeId, trueBranch: boolean): ClosedPentagonDomain {
-		const reducePentagon = (state: ClosedPentagonDomain) => state.create(state.value);
-
 		const { applyConditionSemantics: intervalPositiveSemantics, applyNegatedConditionSemantics: intervalNegativeSemantics } = getIntervalConditionSemantics<ClosedPentagonDomain, this>();
 		const { applyConditionSemantics: upperBoundsPositiveSemantics, applyNegatedConditionSemantics: upperBoundsNegativeSemantics } = getUpperBoundsConditionSemantics<ClosedPentagonDomain, this>();
 
 		const intervalSemantics = trueBranch ? intervalPositiveSemantics : intervalNegativeSemantics;
 		const ubSemantics = trueBranch ? upperBoundsPositiveSemantics : upperBoundsNegativeSemantics;
 
-		return reducePentagon(
-			ubSemantics(
+		const conditionState = ubSemantics(
+			conditionNodeId,
+			intervalSemantics(
 				conditionNodeId,
-				intervalSemantics(
-					conditionNodeId,
-					state,
-					this,
-					this.config.dfg
-				),
+				state,
 				this,
 				this.config.dfg
-			)
+			),
+			this,
+			this.config.dfg
 		);
+
+		return this.removeConstantAndExpressionInfo(conditionNodeId, conditionState);
 	}
 }

--- a/test/functionality/abstract-interpretation/pentagon/inference.test.ts
+++ b/test/functionality/abstract-interpretation/pentagon/inference.test.ts
@@ -75,6 +75,8 @@ describe('Pentagon Inference', () => {
 
 		describe('combined pentagon part', () => {
 			describe('basic combined calculation', () => {
+				// For this example, we can only infer implicit upper bounds via the interval domain, which are not
+				// explicitly present in the upper bounds
 				testPentagonDomain(`
 					x <- 3
 					y <- -4
@@ -84,10 +86,10 @@ describe('Pentagon Inference', () => {
 					invalid <- Inf * zero
 				`, {
 					'1@x':       { interval: IntervalTests.scalar(3), upperBounds: UpperBoundsTests.top() },
-					'2@y':       { interval: IntervalTests.scalar(-4), upperBounds: UpperBoundsTests.bounds(['1@x']) },
-					'3@z':       { interval: IntervalTests.scalar(2.4), upperBounds: UpperBoundsTests.bounds(['1@x']), lowerBounds: UpperBoundsTests.bounds(['2@y']) },
-					'4@result':  { interval: IntervalTests.scalar(3*3-(-4)*2.4), upperBounds: UpperBoundsTests.top(), lowerBounds: UpperBoundsTests.bounds(['1@x']) },
-					'5@zero':    { interval: IntervalTests.scalar(0), upperBounds: UpperBoundsTests.bounds(['1@x', '3@z']), lowerBounds: UpperBoundsTests.bounds(['2@y']) },
+					'2@y':       { interval: IntervalTests.scalar(-4), upperBounds: UpperBoundsTests.top() },
+					'3@z':       { interval: IntervalTests.scalar(2.4), upperBounds: UpperBoundsTests.top() },
+					'4@result':  { interval: IntervalTests.scalar(3*3-(-4)*2.4), upperBounds: UpperBoundsTests.top() },
+					'5@zero':    { interval: IntervalTests.scalar(0), upperBounds: UpperBoundsTests.top() },
 					'6@invalid': { interval: IntervalTests.top(), upperBounds: UpperBoundsTests.top() }
 				});
 
@@ -97,7 +99,7 @@ describe('Pentagon Inference', () => {
 					z <- x + y
 				`, {
 					'1@x': { interval: IntervalTests.scalar(-Infinity), upperBounds: UpperBoundsTests.top() },
-					'2@y': { interval: IntervalTests.scalar(4), upperBounds: UpperBoundsTests.top(), lowerBounds: UpperBoundsTests.bounds(['1@x']) },
+					'2@y': { interval: IntervalTests.scalar(4), upperBounds: UpperBoundsTests.top() },
 					'3@z': { interval: IntervalTests.scalar(-Infinity), upperBounds: UpperBoundsTests.bounds(['3@y']), lowerBounds: UpperBoundsTests.bounds(['3@x']) },
 				});
 			});

--- a/test/functionality/abstract-interpretation/pentagon/thesis-example.test.ts
+++ b/test/functionality/abstract-interpretation/pentagon/thesis-example.test.ts
@@ -53,8 +53,8 @@ describe('Thesis example', () => {
 			cat(result, low, high)
 		`, {
 			'3@result':  { interval: IntervalTests.scalar(-1), upperBounds: UpperBoundsTests.top() },
-			'4@low':     { interval: IntervalTests.scalar(1), upperBounds: UpperBoundsTests.top(), lowerBounds: UpperBoundsTests.bounds(['3@result']) },
-			'5@high':    { interval: IntervalTests.interval(0, Infinity), upperBounds: UpperBoundsTests.top(), lowerBounds: UpperBoundsTests.bounds(['3@result']) },
+			'4@low':     { interval: IntervalTests.scalar(1), upperBounds: UpperBoundsTests.top(), lowerBounds: UpperBoundsTests.top() },
+			'5@high':    { interval: IntervalTests.interval(0, Infinity), upperBounds: UpperBoundsTests.top(), lowerBounds: UpperBoundsTests.top() },
 			'6@low':     { interval: IntervalTests.interval(1, Infinity), intervalMatching: DomainMatchingType.Overapproximation, upperBounds: UpperBoundsTests.bounds(['6@high']), lowerBounds: UpperBoundsTests.bounds(['3@result']) },
 			'6@high':    { interval: IntervalTests.interval(1, Infinity), intervalMatching: DomainMatchingType.Overapproximation, upperBounds: UpperBoundsTests.bounds(['3@result']), lowerBounds: UpperBoundsTests.bounds(['6@low']) },
 			'7@mid':     { interval: IntervalTests.interval(1, Infinity), intervalMatching: DomainMatchingType.Overapproximation, upperBounds: UpperBoundsTests.top(), lowerBounds: UpperBoundsTests.bounds(['3@result']) },


### PR DESCRIPTION
Contribution for Iteration 3.

Applied performance optimizations as described in the pentagon paper, where we do not explicitly store all implicit constraints but rather adapt the join and other operators to make these implicit constraints explicit if required.

This reduces the amount of required ram as well as the number of operations (and therefore runtime) significantly, but also possibly looses some information. However, since the interim eval showed that we did not infer more precise intervals with the pentagon domain compared to the interval domain, this might not be too much of a loss.

Additionally added `&` and `|` with the same abstract semantics as `&&` and `||` which should be fine for the usage with numeric scalar values.