### PR TITLE
Fix small abstract interpretation issues on variable definitions, assignments, unsupported functions

### DIFF
--- a/src/abstract-interpretation/absint-visitor.ts
+++ b/src/abstract-interpretation/absint-visitor.ts
@@ -264,7 +264,7 @@ export abstract class AbstractInterpretationVisitor<StateDomain extends AnyState
 	}
 
 	protected override onVariableDefinition({ vertex }: { vertex: DataflowGraphVertexVariableDefinition; }): void {
-		if(this.currentState.get(vertex.id) === undefined) {
+		if(!this.trace.has(vertex.id)) {
 			this.unassigned.add(vertex.id);
 		}
 	}
@@ -278,8 +278,10 @@ export abstract class AbstractInterpretationVisitor<StateDomain extends AnyState
 
 		if(value !== undefined) {
 			this.currentState.set(target, value);
-			this.trace.set(target, this.currentState);
+		} else {
+			this.currentState.remove(target);
 		}
+		this.trace.set(target, this.currentState);
 	}
 
 	protected override onReplacementCall({ target }: { call: DataflowGraphVertexFunctionCall, target?: NodeId, source?: NodeId }): void {
@@ -325,7 +327,7 @@ export abstract class AbstractInterpretationVisitor<StateDomain extends AnyState
 
 	/** Checks whether a node represents a unsupported (environment-changing) function call (e.g. `eval`, `load`, `attach`, `rm`, ...) */
 	protected isUnsupportedFunctionCall(nodeId: NodeId): boolean {
-		return UnsupportedFunctions.isUnsupportedCall(this.getDataflowGraph(nodeId));
+		return UnsupportedFunctions.isUnsupportedCall(this.getDataflowGraph(nodeId), this.config.dfg);
 	}
 
 	/** We only perform widening at `for`, `while`, or `repeat` loops with more than one ingoing CFG edge */

--- a/src/abstract-interpretation/unsupported-functions.ts
+++ b/src/abstract-interpretation/unsupported-functions.ts
@@ -1,10 +1,19 @@
 import { Identifier } from '../dataflow/environments/identifier';
-import { type DataflowGraphVertexArgument, isFunctionCallVertex } from '../dataflow/graph/vertex';
+import type { DataflowGraph } from '../dataflow/graph/graph';
+import { type DataflowGraphVertexArgument, type DataflowGraphVertexFunctionCall, isFunctionCallVertex } from '../dataflow/graph/vertex';
+
+/**
+ * Function info for unsupported functions that may change the environment unresolvable/implicitly.
+ */
+interface UnsupportedFunctionInfo {
+	package:    string;
+	condition?: (vertex: DataflowGraphVertexFunctionCall, dfg: DataflowGraph) => boolean;
+}
 
 /**
  * List of known function calls that may change the environment unresolvable/implicitly.
  */
-const UnsupportedFunctionsList = {
+const UnsupportedFunctionsList: Record<string, UnsupportedFunctionInfo> = {
 	'.Primitive':          { package: 'base' },
 	'.Internal':           { package: 'base' },
 	'.External':           { package: 'base' },
@@ -26,18 +35,25 @@ const UnsupportedFunctionsList = {
 	'rm':                  { package: 'base' },
 	'remove':              { package: 'base' },
 	'list2env':            { package: 'base' },
+	'assign':              { package: 'base', condition: (vertex, dfg) => dfg.unknownSideEffects.has(vertex.id) },
+	'delayedAssign':       { package: 'base', condition: (vertex, dfg) => dfg.unknownSideEffects.has(vertex.id) },
 	'assignInNamespace':   { package: 'utils' },
 	'assignInMyNamespace': { package: 'utils' },
-} as const satisfies Record<string, { package: string }>;
+};
 
 /**
  * Helper for unsupported functions that may change the environment.
  */
 export const UnsupportedFunctions = {
 	/**
-	 * Checks whether a data flow graph vertex represents a unsupported (environment-changing) function call (e.g. `eval`, `load`, `attach`, `rm`, ...)
+	 * Checks whether a data flow graph vertex represents an unsupported (environment-changing) function call (e.g. `eval`, `load`, `attach`, `rm`, ...)
 	 */
-	isUnsupportedCall(this: void, vertex: DataflowGraphVertexArgument | undefined): boolean {
-		return isFunctionCallVertex(vertex) && Object.hasOwn(UnsupportedFunctionsList, Identifier.getName(vertex.name));
+	isUnsupportedCall(this: void, vertex: DataflowGraphVertexArgument | undefined, dfg: DataflowGraph): boolean {
+		if(!isFunctionCallVertex(vertex)) {
+			return false;
+		}
+		const identifier = Identifier.getName(vertex.name);
+
+		return Object.hasOwn(UnsupportedFunctionsList, identifier) && (UnsupportedFunctionsList[identifier].condition?.(vertex, dfg) ?? true);
 	}
 };

--- a/src/abstract-interpretation/unsupported-functions.ts
+++ b/src/abstract-interpretation/unsupported-functions.ts
@@ -1,45 +1,50 @@
 import { Identifier } from '../dataflow/environments/identifier';
 import type { DataflowGraph } from '../dataflow/graph/graph';
 import { type DataflowGraphVertexArgument, type DataflowGraphVertexFunctionCall, isFunctionCallVertex } from '../dataflow/graph/vertex';
+import { Record } from '../util/record';
 
-/**
- * Function info for unsupported functions that may change the environment unresolvable/implicitly.
- */
 interface UnsupportedFunctionInfo {
-	package:    string;
-	condition?: (vertex: DataflowGraphVertexFunctionCall, dfg: DataflowGraph) => boolean;
+	readonly condition?: (vertex: DataflowGraphVertexFunctionCall, dfg: DataflowGraph) => boolean;
+}
+
+interface UnsupportedFunctionEntry extends UnsupportedFunctionInfo {
+	readonly identifier: Identifier;
+}
+
+function unsupportedFunctions(functions: Record<`${string}::${string}`, UnsupportedFunctionInfo>): readonly UnsupportedFunctionEntry[] {
+	return Record.entries(functions).map(([identifier, info]) => ({ identifier: Identifier.parse(identifier), ...info }));
 }
 
 /**
  * List of known function calls that may change the environment unresolvable/implicitly.
  */
-const UnsupportedFunctionsList: Record<string, UnsupportedFunctionInfo> = {
-	'.Primitive':          { package: 'base' },
-	'.Internal':           { package: 'base' },
-	'.External':           { package: 'base' },
-	'.Call':               { package: 'base' },
-	'.C':                  { package: 'base' },
-	'.Fortran':            { package: 'base' },
-	'.dyn.load':           { package: 'base' },
-	'eval':                { package: 'base' },
-	'evalq':               { package: 'base' },
-	'eval.parent':         { package: 'base' },
-	'eval_tidy':           { package: 'rlang' },
-	'eval_bare':           { package: 'rlang' },
-	'body<-':              { package: 'base' },
-	'formals<-':           { package: 'base' },
-	'environment<-':       { package: 'base' },
-	'load':                { package: 'base' },
-	'attach':              { package: 'base' },
-	'detach':              { package: 'base' },
-	'rm':                  { package: 'base' },
-	'remove':              { package: 'base' },
-	'list2env':            { package: 'base' },
-	'assign':              { package: 'base', condition: (vertex, dfg) => dfg.unknownSideEffects.has(vertex.id) },
-	'delayedAssign':       { package: 'base', condition: (vertex, dfg) => dfg.unknownSideEffects.has(vertex.id) },
-	'assignInNamespace':   { package: 'utils' },
-	'assignInMyNamespace': { package: 'utils' },
-};
+const UnsupportedFunctionsList = unsupportedFunctions({
+	'base::.Primitive':           {},
+	'base::.Internal':            {},
+	'base::.External':            {},
+	'base::.Call':                {},
+	'base::.C':                   {},
+	'base::.Fortran':             {},
+	'base::.dyn.load':            {},
+	'base::eval':                 {},
+	'base::evalq':                {},
+	'base::eval.parent':          {},
+	'rlang::eval_tidy':           {},
+	'rlang::eval_bare':           {},
+	'base::body<-':               {},
+	'base::formals<-':            {},
+	'base::environment<-':        {},
+	'base::load':                 {},
+	'base::attach':               {},
+	'base::detach':               {},
+	'base::rm':                   {},
+	'base::remove':               {},
+	'base::list2env':             {},
+	'base::assign':               { condition: (vertex, dfg) => dfg.unknownSideEffects.has(vertex.id) },
+	'base::delayedAssign':        { condition: (vertex, dfg) => dfg.unknownSideEffects.has(vertex.id) },
+	'utils::assignInNamespace':   {},
+	'utils::assignInMyNamespace': {},
+});
 
 /**
  * Helper for unsupported functions that may change the environment.
@@ -52,8 +57,8 @@ export const UnsupportedFunctions = {
 		if(!isFunctionCallVertex(vertex)) {
 			return false;
 		}
-		const identifier = Identifier.getName(vertex.name);
+		const entry = UnsupportedFunctionsList.find(entry => Identifier.matches(vertex.name, entry.identifier));
 
-		return Object.hasOwn(UnsupportedFunctionsList, identifier) && (UnsupportedFunctionsList[identifier].condition?.(vertex, dfg) ?? true);
+		return entry !== undefined && (entry.condition?.(vertex, dfg) ?? true);
 	}
 };

--- a/test/functionality/abstract-interpretation/data-frame/inference.test.ts
+++ b/test/functionality/abstract-interpretation/data-frame/inference.test.ts
@@ -67,6 +67,19 @@ print(df6)
 		testInferredDataFrameShape(
 			shell,
 			`
+df1 <- data.frame(id = 1:5)
+assign(paste0("df1"), 42)
+print(df1)
+			`,
+			{
+				'1@df1': { colnames: [['id'], []], cols: [1, 1], rows: [5, 5] },
+				'3@df1': undefined
+			}
+		);
+
+		testInferredDataFrameShape(
+			shell,
+			`
 \`df1\` <- data.frame(id = 1:5)
 'df2' <- data.frame(id = 1:5)
 "df3" <- data.frame(id = 1:5)
@@ -369,6 +382,20 @@ if (2 < 1) {
 print(df)
 				`,
 				['4@df']
+			);
+
+			testInferredDataFrameShape(
+				shell,
+				`
+df <- data.frame(id = 1:5)
+for (i in 1:2) {
+	df[2] <- 42
+	print(df)
+	eval(parse(text = paste("df", "<-", "1:2")))
+}
+print(df)
+				`,
+				['1@df', '4@df', '7@df']
 			);
 		});
 	});

--- a/test/functionality/abstract-interpretation/inference.ts
+++ b/test/functionality/abstract-interpretation/inference.ts
@@ -227,11 +227,13 @@ export async function validateInferredValues<Domain extends AnyAbstractDomain>(
 
 	for(const { criterion, inferred } of testEntries) {
 		const marker = createMarker(criterion);
-		const line = output.find(line => line.includes(marker));
-		guard(isNotUndefined(line), `Cannot parse output of instrumented code for ${criterion}`);
 
-		const expected = parseOutput(line);
-		assertInferredValue(criterion, inferred, expected, options?.matchingType ?? DomainMatchingType.Overapproximation);
+		for(const line of output.filter(line => line.includes(marker))) {
+			guard(isNotUndefined(line), `Cannot parse output of instrumented code for ${criterion}`);
+
+			const expected = parseOutput(line);
+			assertInferredValue(criterion, inferred, expected, options?.matchingType ?? DomainMatchingType.Overapproximation);
+		}
 	}
 }
 


### PR DESCRIPTION
This PR provides fixes to:
- Check trace for unassigned variables at variable definitions instead of current state (#2523)
- Allow setting variables to `undefined` (Top) in assignments (#2542)
- Functions with unknown environment side effects that are partially supported, such as `assign` (#2523)

The issue with early terminated fixpoint iterations due to unsupported functions at the end of loops is not fixed, but a test case is added to document the issue

Closes #2523, closes #2542