### PR TITLE
fix: escape Mermaid reserved keywords in node IDs

### DIFF
--- a/src/util/mermaid/mermaid.ts
+++ b/src/util/mermaid/mermaid.ts
@@ -54,10 +54,20 @@ export const Mermaid = {
 		return text;
 	},
 	/**
+	 * Mermaid reserved keywords that cannot be used as bare node IDs.
+	 * When a node ID matches one of these, Mermaid's lexer will tokenize it as
+	 * a keyword token instead of an identifier, causing parse errors.
+	 */
+	reservedKeywords: ['class', 'subgraph', 'end', 'click', 'link', 'style', 'graph', 'flowchart'],
+	/**
 	 * Escapes a string or number to be used as a mermaid node id.
+	 * Also handles Mermaid reserved keywords to prevent parse errors.
 	 */
 	escapeId(this: void, text: string | number): string {
-		text = String(text).replace(/[^a-zA-Z0-9:-]/g, '_');
+		text = String(text).replace(/[^a-zA-Z0-9_-]/g, '_');
+		if(text.length > 0 && (Mermaid.reservedKeywords as readonly string[]).includes(text)) {
+			text = 'n_' + text;
+		}
 		return text;
 	},
 	/**


### PR DESCRIPTION
## What's wrong

The dataflow graph for R code containing the unbound identifier `class` generates invalid Mermaid syntax. Mermaid's lexer tokenizes `class` as a `CLASS` keyword, causing a parse error when the graph is rendered.

## What this does

Two changes in `escapeId` in `src/util/mermaid/mermaid.ts`:

1. Replaced `:` with `_` in the allowed character set for node IDs. Previously `built-in:class` was kept as-is, and the `:` created a word boundary that made Mermaid's lexer see `class` as a separate keyword token. Now it becomes `built-in_class` — a single token the parser handles fine.

2. Added a reserved-keyword check so node IDs that exactly match Mermaid keywords (`class`, `subgraph`, `end`, `click`, `link`, `style`, `graph`, `flowchart`) get prefixed with `n_` to prevent tokenizer conflicts.

## How to verify

```bash
:query @dataflow "class"
```

Before the fix, this generated `built-in:class["\`Built-In:\nclass\`"]` — Mermaid's parser fails with `got 'CLASS'`. After the fix, the node ID is `built-in_class` and the graph renders correctly.

Existing tests pass (confirmed via `vitest run test/functionality/control-flow/cfg-mermaid.test.ts`).

Fixes #2609
