### PR TITLE
Add OpenSearch Description File for SigDB

### DIFF
--- a/scripts/gen-sigdb-index.ts
+++ b/scripts/gen-sigdb-index.ts
@@ -32,9 +32,24 @@ async function ranker(): Promise<string> {
 	return `${bundled.outputFiles[0].text}\nconst rankName = NameRank.rankName;`;
 }
 
+const SiteUrl = 'https://flowr-analysis.github.io/flowr';
 const Target = path.join('wiki', 'sigdb');
 
 const group = (n: number): string => n.toLocaleString('en-US');
+
+/**
+ * The OpenSearch description, used by browsers to offer the page as a search engine
+ */
+const OpenSearchDescription = `<?xml version="1.0" encoding="UTF-8"?>
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/">
+	<ShortName>flowR sigdb</ShortName>
+	<Description>Search the R functions flowR knows across base R and CRAN packages.</Description>
+	<InputEncoding>UTF-8</InputEncoding>
+	<Image height="16" width="16" type="image/svg+xml">${SiteUrl}/wiki/img/flowR-mark-red.svg</Image>
+	<Url type="text/html" method="get" template="${SiteUrl}/wiki/sigdb/?q={searchTerms}"/>
+	<Url type="application/opensearchdescription+xml" rel="self" template="${SiteUrl}/wiki/sigdb/opensearch.xml"/>
+</OpenSearchDescription>
+`;
 
 async function main(): Promise<void> {
 	/* the wiki job copies `wiki/` into the wiki repository, which has no business carrying megabytes;
@@ -68,6 +83,10 @@ async function main(): Promise<void> {
 	const target = path.join(Target, 'index.html');
 	fs.writeFileSync(target, page);
 	console.log(`  wrote ${target} (${group(index.packages.length)} packages, ${group(blobs.count)} names, ${group(index.stated.size)} flowR signatures, ${group(index.formals.size)} base R signatures, ${(page.length / 1024 / 1024).toFixed(1)} MB, not committed)`);
+
+	const descriptionTarget = path.join(Target, 'opensearch.xml');
+	fs.writeFileSync(descriptionTarget, OpenSearchDescription);
+	console.log(`  wrote ${descriptionTarget}`);
 }
 
 const Template = fs.readFileSync(path.join('scripts', 'landing-sigdb-template.html'), 'utf8');

--- a/scripts/landing-sigdb-template.html
+++ b/scripts/landing-sigdb-template.html
@@ -6,6 +6,7 @@
 <title>flowR &middot; signature database</title>
 <meta name="description" content="Search the R functions flowR knows: <!--FUNCTIONS--> exported names from <!--PACKAGES--> base-R and CRAN packages, the database behind its sophisticated call resolution.">
 <link rel="icon" href="../img/flowR-mark-red.svg" type="image/svg+xml">
+<link rel="search" type="application/opensearchdescription+xml" title="flowR sigdb" href="opensearch.xml">
 <script>
 	/* the stored theme has to sit on the element before the first paint, or the page flashes the other one */
 	try {


### PR DESCRIPTION
The world was waiting for this! :D 

Helps browsers offer the signature DB as a search engine in the address bar.

<img width="1140" height="483" alt="image" src="https://github.com/user-attachments/assets/14e12dc4-7c08-446b-ba75-aebf3d9f2066" />

On the one hand, it's nice to add the signature DB without having to manually specify the URL.
On the other hand, since browser vendors removed the separate search bar, one still has to actively open the settings to add search engines, AFAIK.

Please note:

> Check that your server serves OpenSearch descriptions with Content-Type: application/opensearchdescription+xml.

https://developer.mozilla.org/en-US/docs/Web/XML/Guides/OpenSearch

It worked on my machine 🤞🏽 